### PR TITLE
Fix/filtros homepage bugs

### DIFF
--- a/backend/src/modules/filtershomepage/filtershomepage.repository.ts
+++ b/backend/src/modules/filtershomepage/filtershomepage.repository.ts
@@ -3,40 +3,42 @@ import { prisma } from "../../db";
 
 export class FiltersHomepageRepository {
   async getCountsByCity(tipoAccion: $Enums.TipoAccion) {
-    const groups = await prisma.ubicacion_maestra.groupBy({
-      by: ["departamento"],
+    const ubicaciones = await prisma.ubicacionInmueble.findMany({
       where: {
-        ubicacion_inmueble: {
-          some: {
-            inmueble: {
-              tipoAccion: tipoAccion,
-              estado: $Enums.EstadoInmueble.ACTIVO,
-            },
+        inmueble: {
+          tipoAccion: tipoAccion,
+          estado: $Enums.EstadoInmueble.ACTIVO,
+        },
+      },
+      select: {
+        inmuebleId: true, 
+        ubicacion_maestra: {
+          select: {
+            departamento: true,
           },
         },
       },
     });
 
-    const counts = await Promise.all(
-      groups.map(async (g) => {
-        const total = await prisma.ubicacionInmueble.count({
-          where: {
-            ubicacion_maestra: {
-              departamento: g.departamento,
-            },
-            inmueble: {
-              tipoAccion: tipoAccion,
-              estado: $Enums.EstadoInmueble.ACTIVO,
-            },
-          },
-        });
+    const deptCounts = new Map<string, Set<number>>();
 
-        return {
-          departamento: g.departamento,
-          count: total,
-        };
-      }),
-    );
+    for (const u of ubicaciones) {
+      const rawDept = u.ubicacion_maestra?.departamento;
+      if (!rawDept || !u.inmuebleId) continue;
+
+      const normalizedDept = rawDept.trim().toUpperCase();
+
+      if (!deptCounts.has(normalizedDept)) {
+        deptCounts.set(normalizedDept, new Set());
+      }
+      
+      deptCounts.get(normalizedDept)!.add(u.inmuebleId);
+    }
+
+    const counts = Array.from(deptCounts.entries()).map(([dept, ids]) => ({
+      departamento: dept, 
+      count: ids.size,
+    }));
 
     return counts.sort((a, b) => b.count - a.count);
   }

--- a/backend/src/modules/filtershomepage/filtershomepage.service.ts
+++ b/backend/src/modules/filtershomepage/filtershomepage.service.ts
@@ -16,13 +16,26 @@ export class FiltersHomepageService {
       count: item.count,
     });
 
+    const requiredCategories = [
+      { id: 'CASA', label: 'Casa' },
+      { id: 'DEPARTAMENTO', label: 'Departamento' },
+      { id: 'OFICINA', label: 'Oficina' },
+      { id: 'TERRENO', label: 'Terreno' },
+      { id: 'CEMENTERIO', label: 'Cementerio' }
+    ];
+
+    const categoriesMapped = requiredCategories.map(reqCat => {
+      const found = categoriesRaw.find((c: any) => c.categoria === reqCat.id);
+      return {
+        name: reqCat.label,
+        count: found ? found._count.id : 0
+      };
+    });
+
     return {
       rentals: rentalsRaw.map(mapToHomeFilter),
       sales: salesRaw.map(mapToHomeFilter),
-      categories: categoriesRaw.map((c: any) => ({
-        name: c.categoria || "Otros",
-        count: c._count.id,
-      })),
-    };
+      categories: categoriesMapped
+    }
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -48,7 +48,7 @@ export default async function Home() {
 
       {/* Contenido Unificado: Tu FilterPanel + ExploreSection */}
       <div className="container mx-auto px-4 py-12">
-        <div className="flex flex-col-reverse lg:flex-row gap-8 items-start">
+        <div className="flex flex-col-reverse md:flex-row gap-8 items-start">
           {/* Sección de Filtros (Columna Izquierda) */}
           <FilterPanel />
 

--- a/frontend/src/components/rentals/FilterPanel.tsx
+++ b/frontend/src/components/rentals/FilterPanel.tsx
@@ -36,13 +36,17 @@ const FilterSection: React.FC<FilterSectionProps> = ({
         {logic.visibleData.map((item: FilterItem) => (
           <div
             key={item.name}
-            className="flex justify-between items-center gap-3 group cursor-pointer transition-all"
+            className="flex justify-between items-start gap-3 group cursor-pointer transition-all"
           >
-            <span className="text-gray-600 group-hover:text-gray-900 text-sm font-medium font-inter transition-all">
+            <span 
+              className="text-gray-600 group-hover:text-gray-900 text-sm font-medium font-inter transition-all flex-1 min-w-0 truncate"
+              title={formatName(item.name)}
+            >
               {formatName(item.name)}
             </span>
-            <span className="text-gray-500 text-sm font-medium font-inter">
-              {item.count.toLocaleString()} {itemLabel}
+            <span className="text-gray-500 text-sm font-medium font-inter text-right max-w-[60%] break-all leading-tight">
+              
+              {Number(item.count).toLocaleString('es-BO')} {itemLabel}
             </span>
           </div>
         ))}
@@ -205,7 +209,7 @@ export default function FilterPanel() {
           }}
           className={`text-sm font-medium transition-all font-inter outline-none flex items-center gap-0.5 ${sortType === "count" ? "text-orange-500 hover:text-orange-600" : "text-gray-400 hover:text-gray-500"}`}
         >
-          Cant.
+          Cantidad
           <span>
             {sortType === "count" && globalSort === "desc" ? "↓" : "↑"}
           </span>
@@ -216,14 +220,11 @@ export default function FilterPanel() {
 
   return (
     <>
-      {/* --- VISTA MÓVIL --- */}
       <div className="lg:hidden w-full mb-8">
-        {/* Ahora la cabecera es igual a la de PC */}
         <div className="px-2">
           <FilterHeader />
         </div>
 
-        {/* Píldoras de selección */}
         <div className="flex gap-2 overflow-x-auto pb-4 px-2 scrollbar-hide">
           <button
             onClick={() => setMobileTab("alquiler")}
@@ -245,7 +246,6 @@ export default function FilterPanel() {
           </button>
         </div>
 
-        {/* Contenido dinámico */}
         <div className="bg-white p-6 rounded-3xl border border-gray-100 shadow-sm mx-2">
           {mobileTab === "alquiler" && (
             <FilterSection
@@ -274,7 +274,6 @@ export default function FilterPanel() {
         </div>
       </div>
 
-      {/* --- VISTA DESKTOP --- */}
       <aside className="hidden lg:block w-80 bg-white p-8 rounded-2xl shadow-[0_10px_40px_rgba(0,0,0,0.06)] border border-gray-100 h-fit sticky top-20 shrink-0">
         <FilterHeader />
 

--- a/frontend/src/components/rentals/FilterPanel.tsx
+++ b/frontend/src/components/rentals/FilterPanel.tsx
@@ -123,7 +123,7 @@ export default function FilterPanel() {
 
   if (loading) {
     return (
-      <div className="w-full lg:w-80 bg-white p-8 rounded-3xl lg:rounded-2xl border border-gray-100 shadow-sm lg:shadow-[0_10px_40px_rgba(0,0,0,0.06)] mb-8 lg:sticky lg:top-20 shrink-0 flex items-center justify-center">
+      <div className="w-full md:w-80 bg-white p-8 rounded-3xl md:rounded-2xl border border-gray-100 shadow-sm md:shadow-[0_10px_40px_rgba(0,0,0,0.06)] mb-8 md:sticky md:top-20 shrink-0 flex items-center justify-center">
         <span className="text-gray-500 italic font-inter font-medium text-sm animate-pulse">
           Sincronizando filtros...
         </span>
@@ -133,7 +133,7 @@ export default function FilterPanel() {
 
   if (hasError) {
     return (
-      <div className="w-full lg:w-80 bg-white p-8 rounded-3xl lg:rounded-2xl border border-gray-100 shadow-sm lg:shadow-[0_10px_40px_rgba(0,0,0,0.06)] mb-8 lg:sticky lg:top-20 shrink-0 flex flex-col items-center justify-center text-center gap-4">
+      <div className="w-full md:w-80 bg-white p-8 rounded-3xl md:rounded-2xl border border-gray-100 shadow-sm md:shadow-[0_10px_40px_rgba(0,0,0,0.06)] mb-8 md:sticky md:top-20 shrink-0 flex flex-col items-center justify-center text-center gap-4">
         <div className="bg-orange-50 p-4 rounded-full">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -220,7 +220,7 @@ export default function FilterPanel() {
 
   return (
     <>
-      <div className="lg:hidden w-full mb-8">
+      <div className="md:hidden w-full mb-8">
         <div className="px-2">
           <FilterHeader />
         </div>
@@ -274,7 +274,7 @@ export default function FilterPanel() {
         </div>
       </div>
 
-      <aside className="hidden lg:block w-80 bg-white p-8 rounded-2xl shadow-[0_10px_40px_rgba(0,0,0,0.06)] border border-gray-100 h-fit sticky top-20 shrink-0">
+      <aside className="hidden md:block w-80 bg-white p-8 rounded-2xl shadow-[0_10px_40px_rgba(0,0,0,0.06)] border border-gray-100 h-fit sticky md:top-20 shrink-0">
         <FilterHeader />
 
         <div className="space-y-6">


### PR DESCRIPTION
Se resolvieron múltiples bugs reportados por QA en la sección de filtros de la Homepage, abarcando UI, responsive design y consultas a la base de datos.

- Bug 12: Se agregó el separador de miles formato 'es-BO' en las cantidades.
- Bug 3.6: Se truncó el texto largo de los departamentos para evitar desbordamientos.
- Bug 3.4: Se corrigio la visibilidad de la categoría 'Cementerio' con conteo 0 en el servicio.
- Bug 3.1: Se ajustaron los breakpoints de `lg` a `md` en `FilterPanel` y `page.tsx` para evitar el colapso prematuro del layout en pantallas medianas.
- Bugs 3.1.1.1 y 3.5 (Backend): Se refactorizó `filtershomepage.repository.ts` usando `findMany` y agrupación manual para evitar pérdidas de datos causadas por el `groupBy` de Prisma. 

Los datos de la sección "Alquileres" y demas datos en "En venta" seguirán mostrándose vacíos o en cero hasta que se corrijan los datos huérfanos (`ubicacionMaestraId` en `NULL`) en la tabla `ubicacion_inmueble` de la base de datos.