### PR TITLE
ci: agregar --no-engine a prisma generate en CI/CD

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
         run: pnpm install
 
       - name: Generar Prisma Client
-        run: pnpm --filter backend prisma generate
+        run: pnpm --filter backend prisma generate --no-engine
 
       - name: Type check backend
         run: pnpm --filter backend tsc --noEmit
@@ -84,7 +84,7 @@ jobs:
         run: pnpm install
 
       - name: Generar Prisma Client
-        run: pnpm --filter backend prisma generate
+        run: pnpm --filter backend prisma generate --no-engine
 
       - name: Build backend
         run: pnpm --filter backend run build


### PR DESCRIPTION
DESCRIPCIÓN:
- Agregar flag --no-engine al comando prisma generate
- Aplicar en jobs: type-check y build-backend

JUSTIFICACIÓN TÉCNICA:
- Evita validación del schema contra base de datos real
- Reduce tiempo de ejecución del CI
- Previene fallos por diferencias entre schema local y BD remota
- Solución para errores TS2305 (modulos no exportados)

BENEFICIOS:
- CI más rápido y estable
- Elimina dependencia de DATABASE_URL en tiempo de build
- Permite type checking sin conexión a BD

IMPACTO:
- No afecta funcionalidad de producción
- No modifica base de datos
- Solo afecta pipeline de CI/CD

SPRINT: 2
MÓDULO: Mi Perfil