### PR TITLE
Feature/publicacion hu3 resumen final backend v2

### DIFF
--- a/backend/src/modules/publicacion/publicacion.controller.ts
+++ b/backend/src/modules/publicacion/publicacion.controller.ts
@@ -6,15 +6,16 @@ import {
 } from './publicacion.service.js'
 
 interface AuthRequest extends Request {
-  usuario?: {
+  user?: {
     id: number
+    correo?: string
     nombre?: string
     rol?: string
   }
 }
 
 export const listarMisPublicacionesController = async (req: AuthRequest, res: Response) => {
-  const usuarioId = req.usuario?.id
+  const usuarioId = req.user?.id
 
   try {
     const publicaciones = await listarMisPublicacionesService(Number(usuarioId))
@@ -42,7 +43,7 @@ export const listarMisPublicacionesController = async (req: AuthRequest, res: Re
 
 export const editarPublicacionController = async (req: AuthRequest, res: Response) => {
   const publicacionId = Number(req.params.id)
-  const usuarioSolicitanteId = req.usuario?.id
+  const usuarioSolicitanteId = req.user?.id
 
   try {
     const resultado = await editarPublicacionService(
@@ -93,7 +94,7 @@ export const editarPublicacionController = async (req: AuthRequest, res: Respons
 
 export const eliminarPublicacionController = async (req: AuthRequest, res: Response) => {
   const publicacionId = Number(req.params.id)
-  const usuarioSolicitanteId = req.usuario?.id
+  const usuarioSolicitanteId = req.user?.id
 
   try {
     const resultado = await eliminarPublicacionService(publicacionId, Number(usuarioSolicitanteId))
@@ -112,16 +113,25 @@ export const eliminarPublicacionController = async (req: AuthRequest, res: Respo
             message: 'El id de la publicación es inválido'
           })
         case 'USUARIO_INVALIDO':
-          return res.status(401).json({ ok: false, message: 'Usuario no autenticado' })
+          return res.status(401).json({
+            ok: false,
+            message: 'Usuario no autenticado'
+          })
         case 'PUBLICACION_NO_EXISTE':
-          return res.status(404).json({ ok: false, message: 'La publicación no existe' })
+          return res.status(404).json({
+            ok: false,
+            message: 'La publicación no existe'
+          })
         case 'NO_AUTORIZADO':
           return res.status(403).json({
             ok: false,
             message: 'No puede eliminar publicaciones de otros usuarios'
           })
         case 'PUBLICACION_YA_ELIMINADA':
-          return res.status(409).json({ ok: false, message: 'La publicación ya fue eliminada' })
+          return res.status(409).json({
+            ok: false,
+            message: 'La publicación ya fue eliminada'
+          })
       }
     }
 

--- a/backend/src/modules/publicacion/publicacion.repository.ts
+++ b/backend/src/modules/publicacion/publicacion.repository.ts
@@ -3,6 +3,21 @@ import { prisma } from '../../lib/prisma.client.js'
 const ESTADO_PUBLICACION_ELIMINADA = 'ELIMINADA' as const
 const ESTADO_INMUEBLE_INACTIVO = 'INACTIVO' as const
 
+type TipoAccionValue = 'VENTA' | 'ALQUILER' | 'ANTICRETO'
+
+type ActualizarPublicacionInput = {
+  titulo?: unknown
+  title?: unknown
+  descripcion?: unknown
+  details?: unknown
+  tipoAccion?: unknown
+  operationType?: unknown
+  ubicacion?: unknown
+  location?: unknown
+  precio?: unknown
+  price?: unknown
+}
+
 export const buscarPublicacionesPorUsuarioRepository = async (usuarioId: number) => {
   return prisma.publicacion.findMany({
     where: {
@@ -48,29 +63,126 @@ export const buscarPublicacionPorIdRepository = async (id: number) => {
   })
 }
 
-export const actualizarPublicacionRepository = async (publicacionId: number, data: any) => {
-  const titulo = data.titulo ?? data.title
-  const descripcion = data.descripcion ?? data.details
-  const tipoAccion = data.tipoAccion ?? data.operationType
-  const direccion = data.ubicacion ?? data.location
+export const buscarResumenFinalPorIdRepository = async (publicacionId: number) => {
+  return prisma.publicacion.findUnique({
+    where: { id: publicacionId },
+    select: {
+      id: true,
+      titulo: true,
+      descripcion: true,
+      estado: true,
+      fechaPublicacion: true,
+      usuarioId: true,
+      inmuebleId: true,
+      inmueble: {
+        select: {
+          id: true,
+          titulo: true,
+          tipoAccion: true,
+          categoria: true,
+          precio: true,
+          superficieM2: true,
+          nroCuartos: true,
+          nroBanos: true,
+          descripcion: true,
+          estado: true,
+          ubicacion: {
+            select: {
+              direccion: true,
+              ciudad: true,
+              zona: true,
+              latitud: true,
+              longitud: true
+            }
+          },
+          inmueble_etiqueta: {
+            select: {
+              etiqueta: {
+                select: {
+                  id: true,
+                  nombre: true
+                }
+              }
+            }
+          }
+        }
+      },
+      multimedia: {
+        select: {
+          id: true,
+          url: true,
+          tipo: true,
+          pesoMb: true
+        },
+        orderBy: {
+          id: 'asc'
+        }
+      }
+    }
+  })
+}
 
+export const actualizarPublicacionRepository = async (
+  publicacionId: number,
+  data: ActualizarPublicacionInput
+) => {
+  const tituloRaw = data.titulo ?? data.title
+  const descripcionRaw = data.descripcion ?? data.details
+  const tipoAccionRaw = data.tipoAccion ?? data.operationType
+  const direccionRaw = data.ubicacion ?? data.location
   const precioRaw = data.precio ?? data.price
-  const precio =
-    precioRaw !== undefined && precioRaw !== null && precioRaw !== ''
-      ? Number(precioRaw)
-      : undefined
 
-  const dataToUpdate: any = {}
-  const inmuebleData: any = {}
+  const dataToUpdate: {
+    titulo?: string
+    descripcion?: string
+    inmueble?: {
+      update: {
+        tipoAccion?: TipoAccionValue
+        precio?: number
+        ubicacion?: {
+          update: {
+            direccion: string
+          }
+        }
+      }
+    }
+  } = {}
 
-  if (titulo !== undefined) dataToUpdate.titulo = titulo
-  if (descripcion !== undefined) dataToUpdate.descripcion = descripcion
-  if (tipoAccion !== undefined) inmuebleData.tipoAccion = tipoAccion
-  if (precio !== undefined && !Number.isNaN(precio)) inmuebleData.precio = precio
-  if (direccion !== undefined) {
+  const inmuebleData: {
+    tipoAccion?: TipoAccionValue
+    precio?: number
+    ubicacion?: {
+      update: {
+        direccion: string
+      }
+    }
+  } = {}
+
+  if (tituloRaw !== undefined) {
+    dataToUpdate.titulo = String(tituloRaw).trim()
+  }
+
+  if (descripcionRaw !== undefined) {
+    dataToUpdate.descripcion = String(descripcionRaw).trim()
+  }
+
+  if (tipoAccionRaw !== undefined) {
+    inmuebleData.tipoAccion = String(tipoAccionRaw).trim().toUpperCase() as TipoAccionValue
+  }
+
+  if (
+    precioRaw !== undefined &&
+    precioRaw !== null &&
+    precioRaw !== '' &&
+    !Number.isNaN(Number(precioRaw))
+  ) {
+    inmuebleData.precio = Number(precioRaw)
+  }
+
+  if (direccionRaw !== undefined) {
     inmuebleData.ubicacion = {
       update: {
-        direccion
+        direccion: String(direccionRaw).trim()
       }
     }
   }

--- a/backend/src/modules/publicacion/publicacion.service.ts
+++ b/backend/src/modules/publicacion/publicacion.service.ts
@@ -1,9 +1,30 @@
 import {
   buscarPublicacionesPorUsuarioRepository,
   buscarPublicacionPorIdRepository,
+  buscarResumenFinalPorIdRepository,
   actualizarPublicacionRepository,
   eliminarLogicamentePublicacionRepository
 } from './publicacion.repository.js'
+
+type PublicacionesPorUsuario = Awaited<ReturnType<typeof buscarPublicacionesPorUsuarioRepository>>
+type ResumenFinalRecord = NonNullable<
+  Awaited<ReturnType<typeof buscarResumenFinalPorIdRepository>>
+>
+type ResumenEtiquetaItem = ResumenFinalRecord['inmueble']['inmueble_etiqueta'][number]
+type ResumenMultimediaItem = ResumenFinalRecord['multimedia'][number]
+
+type EditarPublicacionInput = {
+  titulo?: unknown
+  title?: unknown
+  descripcion?: unknown
+  details?: unknown
+  tipoAccion?: unknown
+  operationType?: unknown
+  ubicacion?: unknown
+  location?: unknown
+  precio?: unknown
+  price?: unknown
+}
 
 export const listarMisPublicacionesService = async (usuarioId: number) => {
   if (Number.isNaN(usuarioId) || usuarioId <= 0) {
@@ -11,8 +32,6 @@ export const listarMisPublicacionesService = async (usuarioId: number) => {
   }
 
   const publicaciones = await buscarPublicacionesPorUsuarioRepository(usuarioId)
-
-  type PublicacionesPorUsuario = Awaited<ReturnType<typeof buscarPublicacionesPorUsuarioRepository>>
 
   return publicaciones.map((publicacion: PublicacionesPorUsuario[number]) => ({
     id: publicacion.id,
@@ -28,10 +47,102 @@ export const listarMisPublicacionesService = async (usuarioId: number) => {
   }))
 }
 
+export const obtenerResumenFinalService = async (
+  publicacionId: number,
+  usuarioSolicitanteId: number
+) => {
+  if (Number.isNaN(publicacionId) || publicacionId <= 0) {
+    throw new Error('ID_INVALIDO')
+  }
+
+  if (Number.isNaN(usuarioSolicitanteId) || usuarioSolicitanteId <= 0) {
+    throw new Error('USUARIO_INVALIDO')
+  }
+
+  const resumen = await buscarResumenFinalPorIdRepository(publicacionId)
+
+  if (!resumen) {
+    throw new Error('PUBLICACION_NO_EXISTE')
+  }
+
+  if (resumen.usuarioId !== usuarioSolicitanteId) {
+    throw new Error('NO_AUTORIZADO')
+  }
+
+  if (resumen.estado === 'ELIMINADA') {
+    throw new Error('PUBLICACION_YA_ELIMINADA')
+  }
+
+  const parametrosPersonalizados = resumen.inmueble.inmueble_etiqueta.map(
+    (item: ResumenEtiquetaItem) => item.etiqueta.nombre
+  )
+
+  const imagenes = resumen.multimedia
+    .filter((item: ResumenMultimediaItem) => item.tipo === 'IMAGEN')
+    .map((item: ResumenMultimediaItem) => ({
+      id: item.id,
+      url: item.url,
+      pesoMb: item.pesoMb === null || item.pesoMb === undefined ? null : Number(item.pesoMb)
+    }))
+
+  const videos = resumen.multimedia
+    .filter((item: ResumenMultimediaItem) => item.tipo === 'VIDEO')
+    .map((item: ResumenMultimediaItem) => ({
+      id: item.id,
+      url: item.url,
+      pesoMb: item.pesoMb === null || item.pesoMb === undefined ? null : Number(item.pesoMb)
+    }))
+
+  return {
+    publicacion: {
+      id: resumen.id,
+      titulo: resumen.titulo,
+      descripcion: resumen.descripcion,
+      estado: resumen.estado,
+      fechaPublicacion: resumen.fechaPublicacion
+    },
+    datosGenerales: {
+      tipoOperacion: resumen.inmueble.tipoAccion,
+      tipoInmueble: resumen.inmueble.categoria,
+      precio: Number(resumen.inmueble.precio),
+      areaM2:
+        resumen.inmueble.superficieM2 === null || resumen.inmueble.superficieM2 === undefined
+          ? null
+          : Number(resumen.inmueble.superficieM2)
+    },
+    ubicacion: {
+      direccion: resumen.inmueble.ubicacion?.direccion ?? 'No especificado',
+      ciudad: resumen.inmueble.ubicacion?.ciudad ?? 'No especificado',
+      zona: resumen.inmueble.ubicacion?.zona ?? 'No especificado',
+      latitud:
+        resumen.inmueble.ubicacion?.latitud === null ||
+        resumen.inmueble.ubicacion?.latitud === undefined
+          ? null
+          : Number(resumen.inmueble.ubicacion.latitud),
+      longitud:
+        resumen.inmueble.ubicacion?.longitud === null ||
+        resumen.inmueble.ubicacion?.longitud === undefined
+          ? null
+          : Number(resumen.inmueble.ubicacion.longitud)
+    },
+    caracteristicas: {
+      habitaciones: resumen.inmueble.nroCuartos ?? null,
+      banos: resumen.inmueble.nroBanos ?? null,
+      estacionamiento: 'No especificado'
+    },
+    parametrosPersonalizados,
+    multimedia: {
+      imagenes,
+      videos
+    },
+    soloLectura: true
+  }
+}
+
 export const editarPublicacionService = async (
   publicacionId: number,
   usuarioSolicitanteId: number,
-  data: any
+  data: EditarPublicacionInput
 ) => {
   if (Number.isNaN(publicacionId) || publicacionId <= 0) {
     throw new Error('ID_INVALIDO')


### PR DESCRIPTION
$$ Cambios realizados
- Se alineó la autenticación del módulo `publicacion` para usar `req.user`.
- Se agregó la query `buscarResumenFinalPorIdRepository` en `publicacion.repository.ts`.
- Se agregó `obtenerResumenFinalService` en `publicacion.service.ts`.
- Se mantuvo intacta la lógica existente de listar, editar y eliminar publicaciones.

**$$ Alcance actual
Este avance cubre la base necesaria para construir el endpoint de resumen final usando:
- publicación
- inmueble
- ubicación
- multimedia
- parámetros personalizados**
<img width="672" height="448" alt="Captura de pantalla 2026-04-19 080034" src="https://github.com/user-attachments/assets/96b163fe-c12f-4f30-a86b-8815f7dbdede" />
