### PR TITLE
feat: HU-10 modal de telemetria e integracion con perfil

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,49 +1,61 @@
-import type { Metadata } from 'next'
-import './globals.css'
-import AppShell from '@/components/layout/AppShell'
+import type { Metadata } from "next";
+import "./globals.css";
+import AppShell from "@/components/layout/AppShell";
+import TelemetryTrigger from "@/components/profile/TelemetryTrigger"; // Importamos el activador de la HU-11
 
 export const metadata: Metadata = {
   title: {
-    default: 'PropBol',
-    template: '%s | PropBol'
+    default: "PropBol",
+    template: "%s | PropBol",
   },
   description:
-    'PropBol es una inmobiliaria boliviana con un portal para comprar, alquilar, publicar y descubrir propiedades con información clara y confiable.',
-  applicationName: 'PropBol',
+    "PropBol es una inmobiliaria boliviana con un portal para comprar, alquilar, publicar y descubrir propiedades con información clara y confiable.",
+  applicationName: "PropBol",
   keywords: [
-    'PropBol',
-    'inmobiliaria boliviana',
-    'propiedades en Bolivia',
-    'casas en venta',
-    'alquileres',
-    'anticrético'
+    "PropBol",
+    "inmobiliaria boliviana",
+    "propiedades en Bolivia",
+    "casas en venta",
+    "alquileres",
+    "anticrético",
   ],
   robots: {
     follow: true,
-    index: true
+    index: true,
   },
   openGraph: {
-    title: 'PropBol',
+    title: "PropBol",
     description:
-      'Portal inmobiliario boliviano para comprar, alquilar, publicar y descubrir propiedades.',
-    locale: 'es_BO',
-    siteName: 'PropBol',
-    type: 'website'
+      "Portal inmobiliario boliviano para comprar, alquilar, publicar y descubrir propiedades.",
+    locale: "es_BO",
+    siteName: "PropBol",
+    type: "website",
   },
   twitter: {
-    card: 'summary',
+    card: "summary",
     description:
-      'Portal inmobiliario boliviano para comprar, alquilar, publicar y descubrir propiedades.',
-    title: 'PropBol'
-  }
-}
+      "Portal inmobiliario boliviano para comprar, alquilar, publicar y descubrir propiedades.",
+    title: "PropBol",
+  },
+};
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="es">
       <body className="min-h-screen flex flex-col">
+        {/* El AppShell envuelve el contenido principal */}
         <AppShell>{children}</AppShell>
+
+        {/* Inyectamos el TelemetryTrigger fuera del AppShell 
+          para que controle el retraso de 4 segundos y la 
+          captura automática de zona sin interferir con la UI 
+        */}
+        <TelemetryTrigger />
       </body>
     </html>
-  )
+  );
 }

--- a/frontend/src/components/profile/ProfileCard.tsx
+++ b/frontend/src/components/profile/ProfileCard.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, Suspense } from 'react'
 import { Plus, Trash2, Pencil, Camera, Loader2, User } from 'lucide-react'
+import { useSearchParams } from 'next/navigation'
 import SecurityModal from './SecurityModal'
 import OtpModal from './OtpModal'
 
@@ -20,6 +21,7 @@ interface PerfilData {
   pais: string | null
   genero: string | null
   direccion: string | null
+  fechaNacimiento: string | null
   telefonos: any[] | null
 }
 
@@ -32,7 +34,6 @@ const PAISES = [
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000'
 
-// Función para ocultar el correo (Ej: jo***@gmail.com)
 const ofuscarEmail = (email: string) => {
   if (!email || !email.includes('@')) return email
   const [usuario, dominio] = email.split('@')
@@ -40,7 +41,21 @@ const ofuscarEmail = (email: string) => {
   return `${usuario.substring(0, 2)}***@${dominio}`
 }
 
-export default function ProfileCard() {
+// 1. Renombramos la función interna
+function ProfileCardContent() {
+  const searchParams = useSearchParams()
+  const focusParam = searchParams ? searchParams.get('focus') : null
+  const [isHighlighted, setIsHighlighted] = useState(false)
+
+  useEffect(() => {
+    if (focusParam === 'personal-data') {
+      setIsHighlighted(true)
+      const el = document.getElementById('personal-data-form')
+      el?.scrollIntoView({ behavior: 'smooth' })
+      setTimeout(() => setIsHighlighted(false), 3000)
+    }
+  }, [focusParam])
+
   const [campoEditando, setCampoEditando] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
@@ -51,15 +66,20 @@ export default function ProfileCard() {
   const [pais, setPais] = useState('')
   const [genero, setGenero] = useState('')
   const [direccion, setDireccion] = useState('')
+  const [fechaNacimiento, setFechaNacimiento] = useState('')
   const [avatar, setAvatar] = useState<string | null>(null)
   const [tempAvatar, setTempAvatar] = useState<File | null>(null)
   const [previewAvatar, setPreviewAvatar] = useState<string | null>(null)
-  const [errorNombre, setErrorNombre] = useState('')
+  
+  // Estados para validaciones de error
+  const [errorNombre, setErrorNombre] = useState("");
+  const [errorFechaNacimiento, setErrorFechaNacimiento] = useState("");
 
-  const [originalNombre] = useState('')
-  const [originalPais] = useState('')
-  const [originalGenero] = useState('')
-  const [originalDireccion] = useState('')
+  const [originalNombre, setOriginalNombre] = useState("");
+  const [originalPais, setOriginalPais] = useState("");
+  const [originalGenero, setOriginalGenero] = useState("");
+  const [originalDireccion, setOriginalDireccion] = useState("");
+  const [originalFechaNacimiento, setOriginalFechaNacimiento] = useState("");
 
   const [isSecurityModalOpen, setIsSecurityModalOpen] = useState(false)
   const [isOtpModalOpen, setIsOtpModalOpen] = useState(false)
@@ -99,10 +119,22 @@ export default function ProfileCard() {
         const perfil = data.perfil
         const foto = perfil.avatar || perfil.fotoPerfil || null
         setPerfilData(perfil)
+        
         setNombre(perfil.nombre || '')
+        setOriginalNombre(perfil.nombre || '')
+        
         setPais(perfil.pais || '')
+        setOriginalPais(perfil.pais || '')
+        
         setGenero(perfil.genero || '')
+        setOriginalGenero(perfil.genero || '')
+        
         setDireccion(perfil.direccion || '')
+        setOriginalDireccion(perfil.direccion || '')
+        
+        setFechaNacimiento(perfil.fechaNacimiento || '')
+        setOriginalFechaNacimiento(perfil.fechaNacimiento || '')
+
         setAvatar(foto)
         setOriginalEmail(perfil.correo || '')
         setTempEmail(perfil.correo || '')
@@ -113,14 +145,12 @@ export default function ProfileCard() {
         syncNavbar()
 
         if (perfil.telefonos && Array.isArray(perfil.telefonos) && perfil.telefonos.length > 0) {
-          setTelefonos(
-            perfil.telefonos.map((tel: any, i: number) => ({
-              id: Date.now() + i,
-              numero: tel.numero,
-              pais: PAISES.find((p) => tel.codigoPais === p.codigo)?.nombre || 'Bolivia',
-              codigo: tel.codigoPais
-            }))
-          )
+          setTelefonos(perfil.telefonos.map((tel: any, i: number) => ({
+            id: Date.now() + i,
+            numero: tel.numero,
+            pais: PAISES.find(p => tel.codigoPais === p.codigo)?.nombre || 'Bolivia',
+            codigo: tel.codigoPais
+          })))
         } else {
           setTelefonos([{ id: Date.now(), numero: '', pais: 'Bolivia', codigo: '+591' }])
         }
@@ -132,116 +162,89 @@ export default function ProfileCard() {
     }
   }
 
-  useEffect(() => {
-    cargarPerfil()
-  }, [])
+  useEffect(() => { cargarPerfil() }, [])
 
   const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
   const hasEmailChanged = tempEmail !== originalEmail && isValidEmail(tempEmail)
 
   const guardarNombre = async () => {
-    setIsLoading(true)
     try {
-      const response = await fetch(`${API_URL}/api/perfil/usuario/nombre`, {
+      await fetch(`${API_URL}/api/perfil/usuario/nombre`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
         body: JSON.stringify({ nombre })
       })
-      const data = await response.json()
-      if (data.ok) {
-        localStorage.setItem('nombre', nombre)
-        syncNavbar()
-        alert('Nombre actualizado exitosamente')
-        setCampoEditando(null)
-      } else {
-        throw new Error(data.msg)
-      }
+      setOriginalNombre(nombre)
+      localStorage.setItem('nombre', nombre)
+      syncNavbar()
     } catch (error: any) {
-      alert(error.message || 'Error al actualizar nombre')
-    } finally {
-      setIsLoading(false)
+      console.error(error.message)
     }
   }
 
   const guardarPais = async () => {
-    setIsLoading(true)
     try {
-      const response = await fetch(`${API_URL}/api/perfil/usuario/pais`, {
+      await fetch(`${API_URL}/api/perfil/usuario/pais`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
         body: JSON.stringify({ pais })
       })
-      const data = await response.json()
-      if (data.ok) {
-        alert('País actualizado exitosamente')
-        setCampoEditando(null)
-      } else {
-        throw new Error(data.msg)
-      }
+      setOriginalPais(pais)
     } catch (error: any) {
-      alert(error.message || 'Error al actualizar país')
-    } finally {
-      setIsLoading(false)
+      console.error(error.message)
     }
   }
 
   const guardarGenero = async () => {
-    setIsLoading(true)
     try {
-      const response = await fetch(`${API_URL}/api/perfil/usuario/genero`, {
+      await fetch(`${API_URL}/api/perfil/usuario/genero`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
         body: JSON.stringify({ genero })
       })
-      const data = await response.json()
-      if (data.ok) {
-        alert('Género actualizado exitosamente')
-        setCampoEditando(null)
-      } else {
-        throw new Error(data.msg)
-      }
+      setOriginalGenero(genero)
     } catch (error: any) {
-      alert(error.message || 'Error al actualizar género')
-    } finally {
-      setIsLoading(false)
+      console.error(error.message)
     }
   }
 
   const guardarDireccion = async () => {
-    setIsLoading(true)
     try {
-      const response = await fetch(`${API_URL}/api/perfil/usuario/direccion`, {
+      await fetch(`${API_URL}/api/perfil/usuario/direccion`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
         body: JSON.stringify({ direccion })
       })
-      const data = await response.json()
-      if (data.ok) {
-        alert('Dirección actualizada exitosamente')
-        setCampoEditando(null)
-      } else {
-        throw new Error(data.msg)
-      }
+      setOriginalDireccion(direccion)
     } catch (error: any) {
-      alert(error.message || 'Error al actualizar dirección')
-    } finally {
-      setIsLoading(false)
+      console.error(error.message)
+    }
+  }
+
+  const guardarFechaNacimiento = async () => {
+    try {
+      await fetch(`${API_URL}/api/perfil/usuario/fecha-nacimiento`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
+        body: JSON.stringify({ fechaNacimiento })
+      })
+      setOriginalFechaNacimiento(fechaNacimiento)
+    } catch (error: any) {
+      console.error(error.message)
     }
   }
 
   const guardarTelefonos = async () => {
-    const numerosLimpios = telefonos.map((t) => t.numero.trim()).filter((num) => num !== '')
-    // 2. VALIDACIÓN DE DUPLICADOS:
-    const tieneDuplicados = new Set(numerosLimpios).size !== numerosLimpios.length
+    const numerosLimpios = telefonos.map((t) => t.numero.trim()).filter((num) => num !== '');
+    const tieneDuplicados = new Set(numerosLimpios).size !== numerosLimpios.length;
 
     if (tieneDuplicados) {
-      alert('No puedes guardar números de teléfono duplicados. Por favor, verifica la información.')
-      return // Detenemos la ejecución si hay repetidos
+      alert('No puedes guardar números de teléfono duplicados. Por favor, verifica la información.');
+      return; 
     }
 
-    setIsLoading(true)
     try {
-      const token = getToken()
+      const token = getToken();
       const body = {
         telefonos: telefonos
           .filter((t) => t.numero.trim() !== '')
@@ -250,31 +253,20 @@ export default function ProfileCard() {
             numero: t.numero,
             principal: index === 0
           }))
-      }
+      };
 
-      const response = await fetch(`${API_URL}/api/perfil/usuario/telefonos`, {
+      await fetch(`${API_URL}/api/perfil/usuario/telefonos`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`
         },
         body: JSON.stringify(body)
-      })
-
-      const data = await response.json()
-      if (data.ok) {
-        alert('Teléfonos actualizados exitosamente')
-        setCampoEditando(null)
-        cargarPerfil()
-      } else {
-        throw new Error(data.msg)
-      }
+      });
     } catch (error: any) {
-      alert(error.message || 'Error al actualizar teléfonos')
-    } finally {
-      setIsLoading(false)
+      console.error(error.message)
     }
-  }
+  };
 
   const subirFoto = async (file: File) => {
     const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
@@ -302,7 +294,6 @@ export default function ProfileCard() {
         setAvatar(nuevaFoto)
         localStorage.setItem('avatar', nuevaFoto)
         syncNavbar()
-        alert('Foto actualizada exitosamente')
         cargarPerfil()
       } else {
         throw new Error(data.msg)
@@ -443,58 +434,54 @@ export default function ProfileCard() {
     setTelefonos(
       telefonos.map((t) => {
         if (t.id === id) {
-          const configPais = PAISES.find((p) => p.nombre === t.pais)
-          const maxDigitos = configPais?.digitos || 15
-
-          const soloNumerosYCortados = valor.replace(/\D/g, '').slice(0, maxDigitos)
-
-          return { ...t, numero: soloNumerosYCortados }
+          const configPais = PAISES.find(p => p.nombre === t.pais);
+          const maxDigitos = configPais?.digitos || 15;
+          const soloNumerosYCortados = valor.replace(/\D/g, '').slice(0, maxDigitos);
+          return { ...t, numero: soloNumerosYCortados };
         }
-        return t
+        return t;
       })
     )
   }
 
-  const handleSaveAll = () => {
+  const handleSaveAll = async () => {
+    setIsLoading(true);
+    
     if (tempAvatar) {
-      subirFoto(tempAvatar)
+      await subirFoto(tempAvatar)
       setTempAvatar(null)
       setPreviewAvatar(null)
     }
     if (isEmailEditable && hasEmailChanged) {
-      solicitarCambioEmail(tempEmail)
+      await solicitarCambioEmail(tempEmail)
     } else if (isEmailEditable && !hasEmailChanged) {
       setIsEmailEditable(false)
     }
 
-    if (campoEditando && campoEditando.startsWith('telefono-')) {
-      guardarTelefonos()
-      return
-    }
+    if (nombre !== originalNombre) await guardarNombre();
+    if (pais !== originalPais) await guardarPais();
+    if (genero !== originalGenero) await guardarGenero();
+    if (direccion !== originalDireccion) await guardarDireccion();
+    if (fechaNacimiento !== originalFechaNacimiento) await guardarFechaNacimiento();
+    
+    await guardarTelefonos();
 
-    if (campoEditando === 'nombre') {
-      guardarNombre()
-    } else if (campoEditando === 'pais') {
-      guardarPais()
-    } else if (campoEditando === 'genero') {
-      guardarGenero()
-    } else if (campoEditando === 'direccion') {
-      guardarDireccion()
-    } else if (campoEditando) {
-      setCampoEditando(null)
-    }
+    setCampoEditando(null);
+    setIsLoading(false);
+    alert('Cambios guardados exitosamente');
   }
 
   const handleCancelAll = () => {
     setCampoEditando(null)
-    if (perfilData) {
-      setNombre(perfilData.nombre || '')
-      setPais(perfilData.pais || '')
-      setGenero(perfilData.genero || '')
-      setDireccion(perfilData.direccion || '')
-    }
+    setNombre(originalNombre)
+    setPais(originalPais)
+    setGenero(originalGenero)
+    setDireccion(originalDireccion)
+    setFechaNacimiento(originalFechaNacimiento)
     setTempEmail(originalEmail)
     setIsEmailEditable(false)
+    setErrorNombre("")
+    setErrorFechaNacimiento("")
   }
 
   const handleEditEmailClick = () => {
@@ -506,8 +493,10 @@ export default function ProfileCard() {
     pais !== originalPais ||
     genero !== originalGenero ||
     direccion !== originalDireccion ||
-    tempEmail !== originalEmail
-  tempAvatar !== null
+    fechaNacimiento !== originalFechaNacimiento ||
+    tempEmail !== originalEmail ||
+    tempAvatar !== null;
+
   if (isLoading && !perfilData) {
     return (
       <div className="flex justify-center items-center h-64">
@@ -517,35 +506,31 @@ export default function ProfileCard() {
   }
 
   return (
-    <div className="bg-[#fdf6e6] border border-[#e5dfd7] shadow-sm p-8 rounded-xl flex flex-col md:flex-row gap-10 items-center">
+    <div 
+      id="personal-data-form" 
+      className={`bg-[#fdf6e6] border border-[#e5dfd7] p-8 rounded-xl flex flex-col md:flex-row gap-10 items-center transition-all duration-700 ${
+        isHighlighted ? 'ring-4 ring-amber-400 shadow-xl shadow-amber-100 scale-[1.01]' : 'shadow-sm'
+      }`}
+    >
       {/* PERFIL */}
       <div className="flex flex-col items-center justify-center w-full md:w-1/3">
         <div className="relative mb-10">
-          {/* AVATAR */}
           <div className="w-28 h-28 rounded-full bg-white border border-gray-300 flex items-center justify-center shadow-sm overflow-hidden">
-            {previewAvatar || (avatar && avatar.trim() !== '') ? (
+             {(previewAvatar || (avatar && avatar.trim() !== "")) ? (
               <img
-                src={previewAvatar || (avatar?.startsWith('http') ? avatar : `${API_URL}${avatar}`)}
-                alt="Foto de perfil"
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <User className="w-10 h-10 text-gray-400" />
+                 src={previewAvatar || (avatar?.startsWith('http') ? avatar : `${API_URL}${avatar}`)}
+                 alt="Foto de perfil"
+                 className="w-full h-full object-cover"
+               />
+              ) : (
+               <User className="w-10 h-10 text-gray-400" />
             )}
           </div>
 
-          {/* BOTÓN + */}
           <button
             onClick={() => fileInputRef.current?.click()}
             disabled={isUploading}
-            className="
-            absolute
-            right-0 top-1/2 translate-x-1/3 -translate-y-1/2   /* 📱 móvil → derecha */
-            md:right-1/2 md:translate-x-1/2 md:top-full md:mt-6  /* 💻 pc → abajo con espacio */
-            w-8 h-8 bg-white border border-gray-300 rounded-full
-            flex items-center justify-center shadow-sm hover:bg-gray-100
-            disabled:opacity-50
-          "
+            className="absolute right-0 top-1/2 translate-x-1/3 -translate-y-1/2 md:right-1/2 md:translate-x-1/2 md:top-full md:mt-6 w-8 h-8 bg-white border border-gray-300 rounded-full flex items-center justify-center shadow-sm hover:bg-gray-100 disabled:opacity-50"
           >
             {isUploading ? <Loader2 size={16} className="animate-spin" /> : <Plus size={16} />}
           </button>
@@ -567,10 +552,7 @@ export default function ProfileCard() {
         </div>
 
         <p className="mt-4 font-semibold text-lg">{nombre}</p>
-        {/* CORREO OCULTO EN LA BARRA LATERAL */}
-        <p className="text-sm text-gray-500">
-          {isEmailEditable ? originalEmail : ofuscarEmail(originalEmail)}
-        </p>
+        <p className="text-sm text-gray-500">{isEmailEditable ? originalEmail : ofuscarEmail(originalEmail)}</p>
       </div>
 
       {/* FORMULARIO */}
@@ -578,61 +560,44 @@ export default function ProfileCard() {
         <h2 className="text-xl font-bold mb-6 text-stone-900">Datos Personales</h2>
 
         <div className="flex flex-col gap-4">
+          
           {/* NOMBRE */}
           <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
             <label className="w-full md:w-40 font-medium text-stone-700">Nombre Completo:</label>
-
             <div className="flex flex-col w-full">
               <div className="flex items-center gap-2">
                 <input
                   type="text"
-                  disabled={campoEditando !== 'nombre'}
                   value={nombre}
+                  onFocus={() => setCampoEditando('nombre')}
                   onChange={(e) => {
-                    setNombre(soloLetras(e.target.value))
-                    if (errorNombre) setErrorNombre('')
+                    setNombre(soloLetras(e.target.value));
+                    if (errorNombre) setErrorNombre("");
                   }}
-                  className={`flex-1 px-3 py-2 rounded text-sm ${
-                    errorNombre
-                      ? 'border border-red-500 bg-red-50'
-                      : campoEditando === 'nombre'
-                        ? 'bg-white border border-amber-500'
-                        : 'bg-gray-200 cursor-not-allowed'
+                  className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                    errorNombre ? "border-red-500 bg-red-50" : campoEditando === 'nombre' ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                   }`}
                 />
-
-                <button
-                  onClick={() => setCampoEditando(campoEditando === 'nombre' ? null : 'nombre')}
-                >
-                  <Pencil size={16} />
-                </button>
               </div>
-
               {errorNombre && <span className="text-red-500 text-xs mt-1">{errorNombre}</span>}
             </div>
           </div>
 
-          {/* EMAIL - ALINEADO Y OCULTO */}
+          {/* EMAIL */}
           <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
             <label className="w-full md:w-40 font-medium text-stone-700">E-mail:</label>
-
             <div className="flex w-full items-center gap-2">
               <input
                 type="email"
-                className={`w-full px-3 py-2 rounded text-sm text-stone-700 ${
-                  isEmailEditable
-                    ? 'bg-white border border-amber-500'
-                    : 'bg-gray-200 cursor-not-allowed'
-                }`}
+                className={`w-full px-3 py-2 rounded text-sm text-stone-700 ${isEmailEditable ? 'bg-white border border-amber-500 focus:outline-none ring-1 ring-amber-500' : 'bg-gray-200 cursor-not-allowed border-stone-300'}`}
                 readOnly={!isEmailEditable}
-                /* CORREO OCULTO EN EL INPUT */
                 value={isEmailEditable ? tempEmail : ofuscarEmail(originalEmail)}
                 onChange={(e) => setTempEmail(e.target.value)}
                 placeholder="correo@ejemplo.com"
               />
               <button
                 onClick={handleEditEmailClick}
-                className="text-black hover:text-amber-600"
+                className="text-stone-500 hover:text-amber-600 transition-colors"
                 disabled={isEmailEditable}
               >
                 <Pencil size={16} />
@@ -640,86 +605,56 @@ export default function ProfileCard() {
             </div>
           </div>
           {isEmailEditable && tempEmail.length > 0 && !isValidEmail(tempEmail) && (
-            <div className="md:ml-44">
-              <span className="text-red-500 text-xs mt-1">Formato de correo inválido</span>
-            </div>
-          )}
-          {isEmailEditable && hasEmailChanged && (
-            <div className="md:ml-44">
-              <span className="text-green-500 text-xs mt-1">Listo para guardar cambios</span>
-            </div>
+            <div className="md:ml-44"><span className="text-red-500 text-xs mt-1">Formato de correo inválido</span></div>
           )}
 
           {/* TELÉFONOS */}
           {telefonos.map((tel, index) => {
             const keyCampo = `telefono-${tel.id}`
             return (
-              <div
-                key={tel.id}
-                className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4"
-              >
+              <div key={tel.id} className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
                 <label className="w-full md:w-40 font-medium text-stone-700">
                   {index === 0 ? 'Teléfono:' : `Teléfono ${index + 1}:`}
                 </label>
                 <div className="flex w-full items-center gap-2">
                   <select
-                    disabled={campoEditando !== keyCampo}
                     value={`${tel.pais} ${tel.codigo}`}
+                    onFocus={() => setCampoEditando(keyCampo)}
                     onChange={(e) => {
-                      const seleccion = PAISES.find(
-                        (p) => `${p.nombre} ${p.codigo}` === e.target.value
-                      )
+                      const seleccion = PAISES.find((p) => `${p.nombre} ${p.codigo}` === e.target.value)
                       if (seleccion) {
-                        setTelefonos(
-                          telefonos.map((t) =>
-                            t.id === tel.id
-                              ? { ...t, pais: seleccion.nombre, codigo: seleccion.codigo }
-                              : t
-                          )
-                        )
+                        setTelefonos(telefonos.map((t) => t.id === tel.id ? { ...t, pais: seleccion.nombre, codigo: seleccion.codigo } : t))
                       }
                     }}
-                    className={`px-2 py-2 rounded text-sm ${
-                      campoEditando === keyCampo
-                        ? 'bg-white border border-amber-500'
-                        : 'bg-gray-200 cursor-not-allowed'
+                    className={`px-2 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                      campoEditando === keyCampo ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                     }`}
                   >
                     {PAISES.map((p) => (
-                      <option key={p.nombre} value={`${p.nombre} ${p.codigo}`}>
-                        {p.flag} {p.codigo}
-                      </option>
+                      <option key={p.nombre} value={`${p.nombre} ${p.codigo}`}>{p.flag} {p.codigo}</option>
                     ))}
                   </select>
                   <input
                     type="text"
                     placeholder="Ej. 70000000"
                     value={tel.numero}
-                    disabled={campoEditando !== keyCampo}
+                    onFocus={() => setCampoEditando(keyCampo)}
                     onChange={(e) => actualizarTelefono(tel.id, e.target.value)}
-                    className={`flex-1 px-3 py-2 rounded text-sm ${
-                      campoEditando === keyCampo
-                        ? 'bg-white border border-amber-500'
-                        : 'bg-gray-200 cursor-not-allowed'
+                    className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                      campoEditando === keyCampo ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                     }`}
                   />
-                  <button
-                    onClick={() => setCampoEditando(campoEditando === keyCampo ? null : keyCampo)}
-                    className="text-black"
-                  >
-                    <Pencil size={16} />
-                  </button>
                   {index === 0 && (
                     <button
                       onClick={agregarTelefono}
                       disabled={telefonos.length >= 3}
-                      className="disabled:opacity-30 disabled:cursor-not-allowed hover:text-orange-600 transition-colors"
+                      className="text-stone-500 disabled:opacity-30 disabled:cursor-not-allowed hover:text-orange-600 transition-colors"
                     >
                       <Plus size={18} />
                     </button>
                   )}
                   {index > 0 && (
-                    <button onClick={() => eliminarTelefono(tel.id)}>
+                    <button onClick={() => eliminarTelefono(tel.id)} className="text-stone-500 hover:text-red-500 transition-colors">
                       <Trash2 size={18} />
                     </button>
                   )}
@@ -733,18 +668,38 @@ export default function ProfileCard() {
             </p>
           )}
 
+          {/* FECHA DE NACIMIENTO */}
+          <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+            <label className="w-full md:w-40 font-medium text-stone-700">F. de Nacimiento:</label>
+            <div className="flex flex-col w-full">
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  value={fechaNacimiento}
+                  onFocus={() => setCampoEditando('fechaNacimiento')}
+                  onChange={(e) => {
+                    setFechaNacimiento(e.target.value)
+                    if (errorFechaNacimiento) setErrorFechaNacimiento("")
+                  }}
+                  className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                    errorFechaNacimiento ? "border-red-500 bg-red-50" : campoEditando === 'fechaNacimiento' ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
+                  }`}
+                />
+              </div>
+              {errorFechaNacimiento && <span className="text-red-500 text-xs mt-1">{errorFechaNacimiento}</span>}
+            </div>
+          </div>
+
           {/* PAÍS */}
           <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
             <label className="w-full md:w-40 font-medium text-stone-700">País:</label>
             <div className="flex w-full items-center gap-2">
               <select
-                disabled={campoEditando !== 'pais'}
                 value={pais}
+                onFocus={() => setCampoEditando('pais')}
                 onChange={(e) => setPais(e.target.value)}
-                className={`flex-1 px-3 py-2 rounded text-sm ${
-                  campoEditando === 'pais'
-                    ? 'bg-white border border-amber-500'
-                    : 'bg-gray-200 cursor-not-allowed'
+                className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                  campoEditando === 'pais' ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                 }`}
               >
                 <option value="">Seleccione un país</option>
@@ -753,9 +708,6 @@ export default function ProfileCard() {
                 <option value="Chile">Chile</option>
                 <option value="Perú">Perú</option>
               </select>
-              <button onClick={() => setCampoEditando(campoEditando === 'pais' ? null : 'pais')}>
-                <Pencil size={16} />
-              </button>
             </div>
           </div>
 
@@ -764,25 +716,19 @@ export default function ProfileCard() {
             <label className="w-full md:w-40 font-medium text-stone-700">Género:</label>
             <div className="flex w-full items-center gap-2">
               <select
-                disabled={campoEditando !== 'genero'}
                 value={genero}
+                onFocus={() => setCampoEditando('genero')}
                 onChange={(e) => setGenero(e.target.value)}
-                className={`flex-1 px-3 py-2 rounded text-sm ${
-                  campoEditando === 'genero'
-                    ? 'bg-white border border-amber-500'
-                    : 'bg-gray-200 cursor-not-allowed'
+                className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                  campoEditando === 'genero' ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                 }`}
               >
                 <option value="">Seleccione género</option>
                 <option value="Masculino">Masculino</option>
                 <option value="Femenino">Femenino</option>
                 <option value="Otro">Otro</option>
+                <option value="Prefiero no decirlo">Prefiero no decirlo</option>
               </select>
-              <button
-                onClick={() => setCampoEditando(campoEditando === 'genero' ? null : 'genero')}
-              >
-                <Pencil size={16} />
-              </button>
             </div>
           </div>
 
@@ -791,20 +737,13 @@ export default function ProfileCard() {
             <label className="w-full md:w-40 font-medium text-stone-700">Dirección:</label>
             <div className="flex w-full items-center gap-2">
               <input
-                disabled={campoEditando !== 'direccion'}
                 value={direccion}
+                onFocus={() => setCampoEditando('direccion')}
                 onChange={(e) => setDireccion(e.target.value)}
-                className={`flex-1 px-3 py-2 rounded text-sm ${
-                  campoEditando === 'direccion'
-                    ? 'bg-white border border-amber-500'
-                    : 'bg-gray-200 cursor-not-allowed'
+                className={`flex-1 px-3 py-2 rounded text-sm bg-white border focus:outline-none transition-colors ${
+                  campoEditando === 'direccion' ? 'border-amber-500 ring-1 ring-amber-500' : 'border-stone-300 hover:border-amber-400'
                 }`}
               />
-              <button
-                onClick={() => setCampoEditando(campoEditando === 'direccion' ? null : 'direccion')}
-              >
-                <Pencil size={16} />
-              </button>
             </div>
           </div>
 
@@ -817,57 +756,72 @@ export default function ProfileCard() {
             >
               Cancelar
             </button>
-
             <button
               onClick={() => {
+                let hasError = false;
+
+                // Validación 1: Nombre
                 if (!nombre.trim()) {
-                  setErrorNombre('El nombre es obligatorio')
-                  return
+                  setErrorNombre("El nombre es obligatorio");
+                  hasError = true;
+                } else {
+                  setErrorNombre("");
                 }
 
-                setErrorNombre('')
-                handleSaveAll()
+                // Validación 2: Edad mínima 18 años (tomando en cuenta el año actual 2026)
+                if (fechaNacimiento) {
+                  const dob = new Date(fechaNacimiento);
+                  const today = new Date(); // El sistema usa 2026 como fecha base
+                  let age = today.getFullYear() - dob.getFullYear();
+                  const m = today.getMonth() - dob.getMonth();
+                  
+                  // Ajuste si el mes/día actual es anterior al de cumpleaños
+                  if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) {
+                    age--;
+                  }
+
+                  if (age < 18) {
+                    setErrorFechaNacimiento("Debes ser mayor de 18 años para registrarte.");
+                    hasError = true;
+                  } else {
+                    setErrorFechaNacimiento("");
+                  }
+                } else {
+                  setErrorFechaNacimiento(""); // Permite pasar porque es un dato opcional
+                }
+
+                if (hasError) return; // Si hay errores, detenemos el guardado
+
+                handleSaveAll();
               }}
               disabled={isLoading || !hayCambios}
-              className={`px-6 py-2 rounded-lg text-sm font-medium shadow-sm transition
-    ${
-      !hayCambios
-        ? 'bg-orange-300 cursor-not-allowed text-white'
-        : 'bg-orange-500 hover:bg-orange-600 text-white'
-    }
-  `}
+              className={`px-6 py-2 rounded-lg text-sm font-medium shadow-sm transition ${
+                !hayCambios ? "bg-orange-300 cursor-not-allowed text-white" : "bg-orange-500 hover:bg-orange-600 text-white"
+              }`}
             >
               {isLoading ? 'Guardando...' : 'Guardar Cambios'}
             </button>
           </div>
+
         </div>
       </div>
 
       {/* MODALES */}
-      <SecurityModal
-        isOpen={isSecurityModalOpen}
-        onClose={() => {
-          setIsSecurityModalOpen(false)
-          setIsLoading(false)
-        }}
-        onSubmit={handlePasswordSubmit}
-        isLoading={isLoading}
-      />
-      <OtpModal
-        isOpen={isOtpModalOpen}
-        onClose={() => {
-          setIsOtpModalOpen(false)
-          setOtpError('')
-          setEmailToUpdate('')
-          setIsLoading(false)
-          setIsEmailEditable(false)
-          setTempEmail(originalEmail)
-        }}
-        onSubmit={handleOtpSubmit}
-        onResendCode={handleResendCode}
-        externalError={otpError}
-        isLoading={isLoading}
-      />
+      <SecurityModal isOpen={isSecurityModalOpen} onClose={() => { setIsSecurityModalOpen(false); setIsLoading(false) }} onSubmit={handlePasswordSubmit} isLoading={isLoading} />
+      <OtpModal isOpen={isOtpModalOpen} onClose={() => { setIsOtpModalOpen(false); setOtpError(''); setEmailToUpdate(''); setIsLoading(false); setIsEmailEditable(false); setTempEmail(originalEmail) }} onSubmit={handleOtpSubmit} onResendCode={handleResendCode} externalError={otpError} isLoading={isLoading} />
     </div>
+  )
+}
+
+// 2. Creamos el envoltorio que exporta el componente hacia el resto del proyecto
+export default function ProfileCard() {
+  return (
+    <Suspense fallback={
+      <div className="flex justify-center items-center h-64">
+        <Loader2 className="w-8 h-8 animate-spin text-orange-500" />
+      </div>
+    }>
+      <ProfileCardContent />
+    </Suspense>
   )
 }

--- a/frontend/src/components/profile/TelemetryModal.tsx
+++ b/frontend/src/components/profile/TelemetryModal.tsx
@@ -1,0 +1,74 @@
+
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+
+interface TelemetryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TelemetryModal: React.FC<TelemetryModalProps> = ({ isOpen, onClose }) => {
+  const router = useRouter();
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-stone-900/40 backdrop-blur-sm animate-in fade-in duration-700">
+      {/* CAMBIO AQUÍ: Se cambió 'max-w-lg' por 'max-w-2xl' para hacerlo más rectangular 
+         y se ajustó el padding a 'p-7' para equilibrar el diseño ancho.
+      */}
+      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full p-7 m-4 border border-[#f5f5f4]">
+        {/* Título - Piedra 900 */}
+        <div className="text-center mb-6">
+          <h2 className="text-2xl font-bold text-[#292524] flex items-center justify-center gap-2">
+            🏠 ¡Ayúdanos a encontrar tu lugar ideal!
+          </h2>
+        </div>
+
+        {/* Cuerpo - Piedra 600 */}
+        <div className="text-[#78716c] text-sm space-y-4 mb-8 leading-relaxed">
+          <p>
+            En <strong>PropBol</strong>, queremos que tu búsqueda sea lo más fluida posible. Para lograrlo, utilizamos herramientas de análisis que nos permiten entender mejor las tendencias del mercado inmobiliario.
+          </p>
+          
+          {/* Caja informativa - Piedra 100 */}
+          <ul className="space-y-3 bg-[#f5f5f4] p-5 rounded-lg border border-stone-200">
+            <li className="flex gap-3">
+              <span className="text-[#D97706] font-bold">•</span>
+              <span><strong>Mejora automática:</strong> Al iniciar sesión, detectamos de forma segura tu zona geográfica de conexión para optimizar los resultados en tu área.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="text-[#D97706] font-bold">•</span>
+              <span><strong>Personalización opcional:</strong> Puedes completar tu género y edad en tu perfil para que el sistema te sugiera propiedades más afines a ti.</span>
+            </li>
+          </ul>
+
+          <p className="text-[11px] italic text-stone-500 text-center">
+            * Recuerda que estos datos son completamente opcionales. Tu privacidad es nuestra prioridad y puedes dejar tu perfil vacío si así lo prefieres.
+          </p>
+        </div>
+
+        {/* Botones - Ámbar y Piedra */}
+        <div className="flex justify-end gap-3 font-semibold">
+          <button 
+            onClick={onClose}
+            className="px-5 py-2 border border-stone-300 text-stone-500 rounded-md hover:bg-[#f5f5f4] transition-colors"
+          >
+            Entendido
+          </button>
+          <button 
+            className="px-5 py-2 bg-[#D97706] text-white rounded-md hover:bg-[#b45309] transition-all shadow-md active:scale-95"
+            onClick={() => {
+              onClose();
+              router.push('/profile?focus=personal-data');
+            }}
+          >
+            Configurar mi Cuenta
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TelemetryModal;

--- a/frontend/src/components/profile/TelemetryTrigger.tsx
+++ b/frontend/src/components/profile/TelemetryTrigger.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState, useEffect } from 'react';
+import TelemetryModal from './TelemetryModal';
+
+export default function TelemetryTrigger() {
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    // 1. Verificamos si hay sesión (Criterio QA)
+    const token = localStorage.getItem('token'); 
+    const hasSeen = localStorage.getItem('has_seen_telemetry');
+
+    if (token && !hasSeen) {
+      // 2. Esperamos los 4 segundos que pediste
+      const timer = setTimeout(() => {
+        // 3. Captura automática de zona (Criterio QA)
+        const zona = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        console.log("HU-11: Zona capturada:", zona);
+        
+        setShowModal(true);
+      }, 10000);
+
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  const handleClose = () => {
+    setShowModal(false);
+    localStorage.setItem('has_seen_telemetry', 'true');
+  };
+
+  return <TelemetryModal isOpen={showModal} onClose={handleClose} />;
+}


### PR DESCRIPTION
Resumen de la PR (HU-10 & Mejoras de Perfil)
Esta PR completa el flujo de la HU-10 y optimiza la experiencia de usuario en la edición de datos personales:

UX de Navegación: Redirección desde el Modal de Telemetría hacia el perfil (?focus=personal-data) con auto-scroll y un efecto de resaltado visual temporal para guiar al usuario.
Edición Fluida (Fricción Cero): Se eliminaron los íconos de "lápiz" para habilitar la edición directa al hacer clic en los campos. (El e-mail mantiene su flujo de seguridad con contraseña y OTP).
Nuevo campo "Fecha de Nacimiento": Campo opcional con validación estricta en el cliente (rechaza menores de 18 años calculando la edad al año actual).
Ajustes menores: Se añadió "Prefiero no decirlo" en las opciones de Género y se adaptó la lógica para guardar múltiples cambios simultáneos.
⚠️ Nota para el equipo Backend: El frontend ya captura y envía el campo fechaNacimiento. Es necesario agregar este campo al schema.prisma y habilitar el endpoint PUT /api/perfil/usuario/fecha-nacimiento para que la base de datos lo reciba.