### PR TITLE
feat(blogs): implementar cabecera responsive y feed visual de HU-10

### DIFF
--- a/frontend/src/app/blogs/page.tsx
+++ b/frontend/src/app/blogs/page.tsx
@@ -1,117 +1,122 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import BlogCard from "@/components/blog/BlogCard";
+import BlogFilterChips from "@/components/blog/BlogFilterChips";
+import FeaturedBlogSpotlight from "@/components/blog/FeaturedBlogSpotlight";
+import { useBlogFeed } from "@/hooks/useBlogFeed";
 
-type Blog = {
-  id: string;
-  title: string;
-  excerpt: string;
-  imageUrl?: string;
-  category: string;
-  author: string;
-  date: string;
-};
+const USER_STORAGE_KEY = "propbol_user";
 
 export default function BlogsPage() {
-  const blogs: Blog[] = [
-    {
-      id: "1",
-      title: "El Auge del Brutalismo Biofílico",
-      excerpt:
-        "Descubre cómo el concreto crudo se fusiona con la naturaleza...",
-      category: "Arquitectura",
-      author: "Admin",
-      date: "2026-04-17",
-      imageUrl: "/img1.jpg",
-    },
-    {
-      id: "2",
-      title: "Ciudades secundarias como nuevo prime",
-      excerpt: "Las ciudades intermedias están atrayendo inversión...",
-      category: "Tendencias",
-      author: "Admin",
-      date: "2026-04-16",
-      imageUrl: "/img2.jpg",
-    },
-    {
-      id: "3",
-      title: "Piscinas minimalistas",
-      excerpt: "El lujo ahora se redefine con menos elementos...",
-      category: "Diseño",
-      author: "Admin",
-      date: "2026-04-15",
-      imageUrl: "/img3.jpg",
-    },
-    {
-      id: "4",
-      title: "Estancias Naturales",
-      excerpt: "La conexión con la naturaleza es tendencia...",
-      category: "Estilo de vida",
-      author: "Admin",
-      date: "2026-04-14",
-      imageUrl: "/img4.jpg",
-    },
-  ];
+  const {
+    activeCategory,
+    categories,
+    featuredBlog,
+    secondaryBlogs,
+    canLoadMore,
+    hasResults,
+    toggleCategory,
+    loadMore,
+  } = useBlogFeed();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  const featured = blogs[0];
-  const rest = blogs.slice(1);
+  useEffect(() => {
+    const syncAuthState = () => {
+      setIsAuthenticated(Boolean(localStorage.getItem(USER_STORAGE_KEY)));
+    };
+
+    syncAuthState();
+    window.addEventListener("storage", syncAuthState);
+    window.addEventListener("propbol:session-changed", syncAuthState);
+
+    return () => {
+      window.removeEventListener("storage", syncAuthState);
+      window.removeEventListener("propbol:session-changed", syncAuthState);
+    };
+  }, []);
 
   return (
-    <div className="bg-[#f7f5f2] min-h-screen">
-      <div className="max-w-7xl mx-auto px-10 py-16">
-
-        {/* 🔥 HEADER */}
-        <div className="mb-20">
-          <span className="text-xs uppercase tracking-widest text-gray-500">
-            Blog
-          </span>
-
-          <h1 className="mt-3 text-5xl font-bold leading-tight text-gray-900 max-w-5xl">
-            Perspectivas para el Bien Raíz Moderno.
+    <div className="min-h-screen bg-[linear-gradient(180deg,#fbf6ef_0%,#f5efe7_45%,#ffffff_100%)]">
+      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+        <section className="space-y-6">
+          <h1 className="max-w-3xl font-heading text-4xl font-bold leading-tight text-stone-900 sm:text-5xl">
+            Perspectivas para el Bien Raiz Moderno.
           </h1>
-        </div>
 
-        {/* 🔥 FEATURED ESTILO REVISTA */}
-        {featured && (
-          <div className="grid lg:grid-cols-2 gap-16 items-center mb-24">
-
-            {/* 🖼️ Imagen dominante */}
-            <div className="overflow-hidden rounded-3xl">
-              <img
-                src={featured.imageUrl || "/placeholder.png"}
-                alt={featured.title}
-                className="w-full h-[450px] lg:h-[500px] object-cover hover:scale-105 transition duration-500"
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="overflow-x-auto pb-1">
+              <BlogFilterChips
+                categories={categories}
+                activeCategory={activeCategory}
+                onToggleCategory={toggleCategory}
               />
             </div>
 
-            {/* 📝 Contenido */}
-            <div className="space-y-6 max-w-xl">
-              <span className="text-xs uppercase tracking-[0.2em] text-orange-500 font-semibold">
-                {featured.category}
-              </span>
-
-              <h2 className="text-3xl md:text-4xl font-bold leading-tight text-gray-900">
-                {featured.title}
-              </h2>
-
-              <p className="text-gray-600 text-base leading-relaxed">
-                {featured.excerpt}
-              </p>
-
-              <button className="text-sm font-semibold text-orange-500 hover:underline">
-                Leer artículo →
-              </button>
-            </div>
+            <button
+              type="button"
+              disabled={!isAuthenticated}
+              aria-disabled={!isAuthenticated}
+              title={
+                isAuthenticated
+                  ? "La creacion de blogs se habilitara cuando el flujo este integrado."
+                  : "Disponible solo para usuarios registrados."
+              }
+              className={`inline-flex min-h-[54px] items-center justify-center self-start px-8 text-sm font-semibold uppercase tracking-[0.22em] transition-colors lg:self-auto ${
+                isAuthenticated
+                  ? "bg-[#a56400] text-white hover:bg-[#8e5800]"
+                  : "cursor-not-allowed bg-[#a56400] text-white/75 opacity-80"
+              }`}
+            >
+              AÑADIR POST
+            </button>
           </div>
+        </section>
+
+        {hasResults && featuredBlog ? (
+          <FeaturedBlogSpotlight blog={featuredBlog} />
+        ) : (
+          <section className="rounded-[32px] border border-dashed border-stone-300 bg-white px-6 py-12 text-center shadow-sm">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-stone-400">
+              Sin resultados
+            </p>
+
+            <h2 className="mt-3 font-heading text-3xl font-bold text-stone-900">
+              No encontramos articulos en esta categoria por ahora.
+            </h2>
+
+            <p className="mx-auto mt-4 max-w-2xl text-base leading-7 text-stone-600">
+              Prueba con otra etiqueta para seguir explorando las publicaciones
+              disponibles.
+            </p>
+          </section>
         )}
 
-        {/* 🟢 GRID DE CARDS */}
-        <div className="grid gap-12 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-          {rest.map((blog) => (
-            <BlogCard key={blog.id} {...blog} />
-          ))}
-        </div>
+        <section className="space-y-6">
+          {secondaryBlogs.length > 0 ? (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {secondaryBlogs.map((blog) => (
+                <BlogCard key={blog.id} {...blog} />
+              ))}
+            </div>
+          ) : hasResults ? (
+            <div className="rounded-[28px] border border-stone-200 bg-white px-6 py-10 text-center text-stone-600 shadow-sm">
+              Esta categoria solo tiene un articulo destacado por el momento.
+            </div>
+          ) : null}
 
+          {canLoadMore && (
+            <div className="flex justify-center pt-2">
+              <button
+                type="button"
+                onClick={loadMore}
+                className="rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-700 transition-colors hover:bg-amber-600 hover:text-white"
+              >
+                CONTINUAR LEYENDO
+              </button>
+            </div>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/components/blog/BlogCard.tsx
+++ b/frontend/src/components/blog/BlogCard.tsx
@@ -4,10 +4,11 @@ type BlogCardProps = {
   id: string;
   title: string;
   excerpt: string;
-  imageUrl?: string;
+  imageUrl: string;
   category: string;
-  author: string;
-  date: string;
+  categoryLabel?: string;
+  authorName: string;
+  publishedAt: string;
   onClick?: (id: string) => void;
 };
 
@@ -17,16 +18,18 @@ export default function BlogCard({
   excerpt,
   imageUrl,
   category,
-  author,
-  date,
+  categoryLabel,
+  authorName,
   onClick,
 }: BlogCardProps) {
   const handleClick = () => {
     onClick?.(id);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Enter") handleClick();
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter") {
+      handleClick();
+    }
   };
 
   return (
@@ -37,50 +40,45 @@ export default function BlogCard({
       tabIndex={onClick ? 0 : undefined}
       aria-label={onClick ? `Abrir blog: ${title}` : undefined}
       className={`
-        group
-        bg-white
-        rounded-2xl
-        border border-gray-200
-        shadow-sm
         overflow-hidden
-        transition-all duration-300
+        rounded-[28px]
+        border
+        border-stone-200
+        bg-white
+        shadow-[0_16px_60px_-40px_rgba(41,37,36,0.45)]
+        transition-all
+        duration-300
         ${
           onClick
-            ? "cursor-pointer hover:shadow-lg hover:-translate-y-1 hover:border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            ? "cursor-pointer hover:-translate-y-1 hover:border-stone-300 hover:shadow-[0_20px_70px_-38px_rgba(41,37,36,0.5)] focus:outline-none focus:ring-2 focus:ring-amber-500"
             : ""
         }
       `}
     >
-      {/* Imagen */}
       <div className="overflow-hidden">
         <img
-          src={imageUrl || "/placeholder.png"}
+          src={imageUrl}
           alt={title}
-          className="w-full h-44 object-cover transition-transform duration-300 group-hover:scale-105"
+          className="h-52 w-full object-cover transition-transform duration-500 hover:scale-105"
         />
       </div>
 
-      <div className="p-4">
-        {/* Categoría */}
-        <span className="text-xs font-semibold text-orange-500 uppercase tracking-wide">
-          {category}
-        </span>
+      <div className="space-y-4 p-5">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-400">
+          <span className="text-amber-700">{categoryLabel ?? category}</span>
+        </div>
 
-        {/* Título */}
-        <h2 className="text-base font-bold mt-1 line-clamp-2">
+        <h2 className="font-heading line-clamp-2 text-xl font-bold leading-snug text-stone-900">
           {title}
         </h2>
 
-        {/* Resumen */}
-        <p className="text-sm text-gray-600 mt-2 line-clamp-3">
+        <p className="line-clamp-3 text-sm leading-6 text-stone-600">
           {excerpt}
         </p>
 
-        {/* Footer */}
-        <div className="flex justify-between items-center mt-4 text-xs text-gray-500">
-          <span>{author}</span>
-          <span>{new Date(date).toLocaleDateString()}</span>
-        </div>
+        <p className="pt-1 text-sm font-semibold uppercase tracking-[0.16em] text-stone-700">
+          {authorName}
+        </p>
       </div>
     </article>
   );

--- a/frontend/src/components/blog/BlogFilterChips.tsx
+++ b/frontend/src/components/blog/BlogFilterChips.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { BlogCategory } from "@/types/publicBlog";
+
+type BlogFilterChipsProps = {
+  categories: readonly BlogCategory[];
+  activeCategory: BlogCategory | null;
+  onToggleCategory: (category: BlogCategory) => void;
+};
+
+const baseChipClassName =
+  "rounded-full border px-4 py-2 text-sm font-semibold uppercase tracking-[0.18em] transition-colors duration-200 whitespace-nowrap";
+
+export default function BlogFilterChips({
+  categories,
+  activeCategory,
+  onToggleCategory,
+}: BlogFilterChipsProps) {
+  return (
+    <div className="flex min-w-max gap-3 sm:min-w-0 sm:flex-wrap">
+      {categories.map((category) => {
+        const isActive = activeCategory === category;
+
+        return (
+          <button
+            key={category}
+            type="button"
+            onClick={() => onToggleCategory(category)}
+            aria-pressed={isActive}
+            className={`${baseChipClassName} ${
+              isActive
+                ? "border-stone-900 bg-stone-900 text-white"
+                : "border-stone-300 bg-white text-stone-700 hover:border-stone-500 hover:text-stone-900"
+            }`}
+          >
+            {category}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/blog/FeaturedBlogSpotlight.tsx
+++ b/frontend/src/components/blog/FeaturedBlogSpotlight.tsx
@@ -1,0 +1,45 @@
+import { PublicBlogCard } from "@/types/publicBlog";
+
+type FeaturedBlogSpotlightProps = {
+  blog: PublicBlogCard;
+};
+
+export default function FeaturedBlogSpotlight({
+  blog,
+}: FeaturedBlogSpotlightProps) {
+  return (
+    <article className="grid gap-6 overflow-hidden rounded-[32px] border border-stone-200 bg-white shadow-[0_24px_80px_-48px_rgba(41,37,36,0.45)] lg:grid-cols-[1.15fr_0.85fr]">
+      <div className="overflow-hidden">
+        <img
+          src={blog.imageUrl}
+          alt={blog.title}
+          className="h-full min-h-[280px] w-full object-cover transition-transform duration-500 hover:scale-[1.03] sm:min-h-[320px]"
+        />
+      </div>
+
+      <div className="flex flex-col justify-center gap-5 px-5 py-7 sm:px-8 lg:px-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-stone-500">
+          {blog.featuredLabel ?? blog.categoryLabel ?? blog.category}
+        </p>
+
+        <div className="space-y-4">
+          <h2 className="font-heading text-3xl font-bold leading-tight text-stone-900 sm:text-4xl">
+            {blog.title}
+          </h2>
+
+          <p className="text-base leading-7 text-stone-600">{blog.excerpt}</p>
+        </div>
+
+        {blog.articleCtaLabel && (
+          <span className="inline-flex text-sm font-semibold uppercase tracking-[0.18em] text-stone-900">
+            {blog.articleCtaLabel}
+          </span>
+        )}
+
+        <p className="pt-1 text-sm font-semibold uppercase tracking-[0.16em] text-stone-700">
+          {blog.authorName}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/hooks/useBlogFeed.ts
+++ b/frontend/src/hooks/useBlogFeed.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BLOG_FILTERS } from "@/lib/mock/publicBlogs.mock";
+import { getPublishedBlogs } from "@/services/blogs.service";
+import { BlogCategory, PublicBlogCard } from "@/types/publicBlog";
+
+const INITIAL_VISIBLE_CARDS = 3;
+
+const sortByPublishedDate = (a: PublicBlogCard, b: PublicBlogCard) =>
+  new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
+
+const orderBlogs = (blogs: PublicBlogCard[]) => {
+  const featuredBlogs = blogs
+    .filter((blog) => blog.isFeatured)
+    .sort(sortByPublishedDate);
+  const regularBlogs = blogs
+    .filter((blog) => !blog.isFeatured)
+    .sort(sortByPublishedDate);
+
+  return [...featuredBlogs, ...regularBlogs];
+};
+
+export const useBlogFeed = () => {
+  const [activeCategory, setActiveCategory] = useState<BlogCategory | null>(
+    null,
+  );
+  const [visibleCards, setVisibleCards] = useState(INITIAL_VISIBLE_CARDS);
+  const publicBlogs = orderBlogs(getPublishedBlogs());
+
+  const filteredBlogs = publicBlogs.filter((blog) =>
+    activeCategory ? blog.category === activeCategory : true,
+  );
+
+  const featuredBlog = filteredBlogs[0] ?? null;
+  const secondaryBlogs = filteredBlogs.slice(1, visibleCards + 1);
+  const canLoadMore = filteredBlogs.length > secondaryBlogs.length + 1;
+
+  useEffect(() => {
+    setVisibleCards(INITIAL_VISIBLE_CARDS);
+  }, [activeCategory]);
+
+  const toggleCategory = (category: BlogCategory) => {
+    setActiveCategory((currentCategory) =>
+      currentCategory === category ? null : category,
+    );
+  };
+
+  return {
+    activeCategory,
+    categories: BLOG_FILTERS,
+    featuredBlog,
+    secondaryBlogs,
+    canLoadMore,
+    hasResults: filteredBlogs.length > 0,
+    toggleCategory,
+    loadMore: () =>
+      setVisibleCards((currentVisibleCards) => currentVisibleCards + 3),
+  };
+};

--- a/frontend/src/lib/mock/publicBlogs.mock.ts
+++ b/frontend/src/lib/mock/publicBlogs.mock.ts
@@ -1,0 +1,226 @@
+import {
+  BLOG_CATEGORIES,
+  BlogRow,
+  PublicBlogCard,
+  mapBlogRowToPublicBlogCard,
+} from "@/types/publicBlog";
+
+export const BLOG_FILTERS = BLOG_CATEGORIES;
+
+const MOCK_BLOG_ROWS: BlogRow[] = [
+  {
+    id: 1,
+    titulo: "El Auge del Brutalismo Biofilico",
+    contenido:
+      "Contenido de ejemplo para el blog destacado de arquitectura.",
+    resumen:
+      "Descubra como los arquitectos lideres fusionan el concreto puro con ecosistemas internos para redefinir el lujo.",
+    imagen:
+      "https://images.unsplash.com/photo-1511818966892-d7d671e672a2?auto=format&fit=crop&w=1400&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-18T09:00:00.000Z",
+    fecha_publicacion: "2026-04-18T10:00:00.000Z",
+    usuario_id: 7,
+    categoria_id: 2,
+    categoria: {
+      id: 2,
+      nombre: "Arquitectura",
+    },
+    usuario: {
+      id: 7,
+      nombre: "Admin",
+      apellido: "PropBol",
+    },
+    destacado: true,
+  },
+  {
+    id: 2,
+    titulo: "Tendencias Globales: Ciudades Secundarias son el Nuevo Prime",
+    contenido: "Contenido de ejemplo para un blog de inversion.",
+    resumen:
+      "A medida que el trabajo remoto madura, el capital de inversion fluye hacia mercados secundarios de alta amenidad como nunca antes.",
+    imagen:
+      "https://images.unsplash.com/photo-1460317442991-0ec209397118?auto=format&fit=crop&w=1400&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-17T09:00:00.000Z",
+    fecha_publicacion: "2026-04-17T10:00:00.000Z",
+    usuario_id: 4,
+    categoria_id: 1,
+    categoria: {
+      id: 1,
+      nombre: "Tendencias",
+    },
+    usuario: {
+      id: 4,
+      nombre: "Julian",
+      apellido: "Thorne",
+    },
+  },
+  {
+    id: 3,
+    titulo: "Psicologia del Espacio: Menos es el Nuevo Mas",
+    contenido: "Contenido de ejemplo para un blog de interiorismo.",
+    resumen:
+      "Explorando como los espacios vacios intencionales impactan en el bienestar mental de los propietarios de alto patrimonio.",
+    imagen:
+      "https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=1200&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-16T09:00:00.000Z",
+    fecha_publicacion: "2026-04-16T10:00:00.000Z",
+    usuario_id: 5,
+    categoria_id: 3,
+    categoria: {
+      id: 3,
+      nombre: "Estilo de vida",
+    },
+    usuario: {
+      id: 5,
+      nombre: "Elena",
+      apellido: "Rossi",
+    },
+  },
+  {
+    id: 4,
+    titulo: "Estancias Net-Zero: El Estandar para Visionarios",
+    contenido: "Contenido de ejemplo para un blog de sustentabilidad.",
+    resumen:
+      "Un analisis profundo de las propiedades autonomas de alta tecnologia que se construyen en el noroeste del Pacifico.",
+    imagen:
+      "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1200&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-15T09:00:00.000Z",
+    fecha_publicacion: "2026-04-15T10:00:00.000Z",
+    usuario_id: 6,
+    categoria_id: 4,
+    categoria: {
+      id: 4,
+      nombre: "Arquitectura",
+    },
+    usuario: {
+      id: 6,
+      nombre: "Marcus",
+      apellido: "Chen",
+    },
+  },
+  {
+    id: 5,
+    titulo: "El Indice del Rascacielos: Prediciendo el Futuro Economico",
+    contenido: "Contenido de ejemplo para un blog adicional de inversion.",
+    resumen:
+      "Como las correlaciones historicas entre el crecimiento vertical y los ciclos del mercado estan informando a los inversionistas institucionales hoy.",
+    imagen:
+      "https://images.unsplash.com/photo-1600585154526-990dced4db0d?auto=format&fit=crop&w=1200&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-13T09:00:00.000Z",
+    fecha_publicacion: "2026-04-13T10:00:00.000Z",
+    usuario_id: 7,
+    categoria_id: 2,
+    categoria: {
+      id: 2,
+      nombre: "Arquitectura",
+    },
+    usuario: {
+      id: 7,
+      nombre: "Julian",
+      apellido: "Thorne",
+    },
+  },
+  {
+    id: 6,
+    titulo: "Arquitectura Sensorial para una Nueva Generacion de Refugios",
+    contenido: "Contenido de ejemplo para un blog adicional de arquitectura.",
+    resumen:
+      "Texturas, luz natural y recorridos fluidos se estan usando para crear espacios que se sienten mas humanos y memorables.",
+    imagen:
+      "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1200&q=80",
+    estado: "PUBLICADO",
+    eliminado: false,
+    fecha_creacion: "2026-04-12T09:00:00.000Z",
+    fecha_publicacion: "2026-04-12T10:00:00.000Z",
+    usuario_id: 8,
+    categoria_id: 1,
+    categoria: {
+      id: 1,
+      nombre: "Tendencias",
+    },
+    usuario: {
+      id: 8,
+      nombre: "Elena",
+      apellido: "Rossi",
+    },
+  },
+];
+
+export const MOCK_PUBLIC_BLOGS: PublicBlogCard[] = MOCK_BLOG_ROWS.map(
+  mapBlogRowToPublicBlogCard,
+)
+  .filter((blog): blog is PublicBlogCard => blog !== null)
+  .map((blog) => {
+    if (blog.id === "1") {
+      return {
+        ...blog,
+        featuredLabel: "ARQUITECTURA DESTACADA",
+        articleCtaLabel: "LEER ARTICULO ->",
+      };
+    }
+
+    if (blog.id === "2") {
+      return {
+        ...blog,
+        categoryLabel: "INVERSION",
+        authorName: "JULIAN THORNE",
+      };
+    }
+
+    if (blog.id === "3") {
+      return {
+        ...blog,
+        categoryLabel: "INTERIORISMO",
+        authorName: "ELENA ROSSI",
+      };
+    }
+
+    if (blog.id === "4") {
+      return {
+        ...blog,
+        categoryLabel: "SUSTENTABILIDAD",
+        authorName: "MARCUS CHEN",
+      };
+    }
+
+    if (blog.id === "5") {
+      return {
+        ...blog,
+        categoryLabel: "INVERSION",
+        authorName: "JULIAN THORNE",
+      };
+    }
+
+    return blog;
+  });
+
+/*
+  Integracion futura con BD:
+  Cuando backend exponga el modulo Blogs basado en las tablas `blog`,
+  `categoria_blog` y `usuario`, reemplace el mock anterior por un fetch
+  al endpoint publico correspondiente y mantenga este mapper.
+
+  Ejemplo de contrato esperado:
+  - blog.id
+  - blog.titulo
+  - blog.resumen o resumen derivado desde blog.contenido
+  - blog.imagen
+  - blog.estado
+  - blog.eliminado
+  - blog.fecha_publicacion
+  - blog.categoria_id + categoria_blog.nombre
+  - blog.usuario_id + usuario.nombre/apellido
+
+  Solo deben mostrarse registros con:
+  estado = "PUBLICADO" y eliminado = false
+*/

--- a/frontend/src/services/blogs.service.ts
+++ b/frontend/src/services/blogs.service.ts
@@ -1,0 +1,22 @@
+import { MOCK_PUBLIC_BLOGS } from "@/lib/mock/publicBlogs.mock";
+import { PublicBlogCard } from "@/types/publicBlog";
+
+export const getPublishedBlogs = (): PublicBlogCard[] => {
+  /*
+    Integracion futura:
+    Cuando exista backend para Blogs, este servicio debe consumir
+    NEXT_PUBLIC_API_URL y mapear la respuesta publica del modulo.
+
+    Ejemplo:
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    const response = await fetch(`${apiUrl}/api/blogs/publicados`, {
+      cache: "no-store",
+    });
+    const rows: BlogRow[] = await response.json();
+    return rows
+      .map(mapBlogRowToPublicBlogCard)
+      .filter((blog): blog is PublicBlogCard => blog !== null);
+  */
+
+  return MOCK_PUBLIC_BLOGS;
+};

--- a/frontend/src/types/publicBlog.ts
+++ b/frontend/src/types/publicBlog.ts
@@ -1,0 +1,76 @@
+export const BLOG_CATEGORIES = [
+  "Tendencias",
+  "Arquitectura",
+  "Inversion",
+  "Estilo de vida",
+] as const;
+
+export type BlogCategory = (typeof BLOG_CATEGORIES)[number];
+
+export type BlogStatus =
+  | "BORRADOR"
+  | "PENDIENTE"
+  | "PUBLICADO"
+  | "RECHAZADO";
+
+export interface CategoriaBlogRow {
+  id: number;
+  nombre: BlogCategory;
+}
+
+export interface BlogAuthorRow {
+  id: number;
+  nombre: string;
+  apellido: string;
+}
+
+export interface BlogRow {
+  id: number;
+  titulo: string;
+  contenido: string;
+  resumen: string;
+  imagen: string;
+  estado: BlogStatus;
+  eliminado: boolean;
+  fecha_creacion: string;
+  fecha_publicacion: string | null;
+  usuario_id: number;
+  categoria_id: number;
+  categoria: CategoriaBlogRow;
+  usuario: BlogAuthorRow;
+  destacado?: boolean;
+}
+
+export interface PublicBlogCard {
+  id: string;
+  title: string;
+  excerpt: string;
+  imageUrl: string;
+  category: BlogCategory;
+  categoryLabel?: string;
+  authorName: string;
+  publishedAt: string;
+  featuredLabel?: string;
+  articleCtaLabel?: string;
+  isFeatured?: boolean;
+}
+
+export const mapBlogRowToPublicBlogCard = (
+  blog: BlogRow,
+): PublicBlogCard | null => {
+  if (blog.estado !== "PUBLICADO" || blog.eliminado || !blog.fecha_publicacion) {
+    return null;
+  }
+
+  return {
+    id: String(blog.id),
+    title: blog.titulo,
+    excerpt: blog.resumen,
+    imageUrl: blog.imagen,
+    category: blog.categoria.nombre,
+    categoryLabel: blog.categoria.nombre,
+    authorName: `${blog.usuario.nombre} ${blog.usuario.apellido}`,
+    publishedAt: blog.fecha_publicacion,
+    isFeatured: blog.destacado ?? false,
+  };
+};


### PR DESCRIPTION
Se implementa la vista pública de Blogs alineada al mockup de HU-10: cabecera editorial con filtros visibles, botón AÑADIR POST en estado seguro para visitors, bloque destacado, tarjetas secundarias y carga progresiva. También se preparó la capa de datos tipada para futura integración con las tablas de blogs, manteniendo por ahora mocks compatibles, para la BD.