### PR TITLE
Feature/filter precio

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -23,6 +23,7 @@ import { useZonas } from '@/hooks/useZonas'
 
 // === COMPONENTES ===
 import FilterBar from '@/components/filters/FilterBar'
+import PriceFilterSidebar from '@/components/filters/PriceFilterSidebar'
 import PropertyCard from '@/components/layout/PropertyCard'
 import PropertyRow from '@/components/galeria/PropertyRow'
 import EmptyState from '@/components/galeria/EmptyState'
@@ -85,6 +86,7 @@ function BusquedaMapaContent() {
   const [sheetState, setSheetState] = useState<SheetState>('peek')
   const [pinnedProperty, setPinnedProperty] = useState<any | null>(null)
   const [isMounted, setIsMounted] = useState(false)
+  const [isPriceFilterOpen, setIsPriceFilterOpen] = useState(false)
 
   // --- INICIO ESTADOS HU8 ---
   const [isDrawingMode, setIsDrawingMode] = useState(false)
@@ -600,6 +602,10 @@ function BusquedaMapaContent() {
         onSearch={(nuevosFiltros) => {
           console.log('🔍 Buscando con filtros:', nuevosFiltros)
         }}
+        onOpenPriceFilter={() => { 
+          setIsPriceFilterOpen(true)
+          setIsSidebarOpen(true)
+        }}
       />
 
       <main className="flex flex-col md:flex-row w-full flex-1 min-h-0 relative overflow-hidden border-b border-stone-200">
@@ -609,7 +615,18 @@ function BusquedaMapaContent() {
             isSidebarOpen ? 'w-full md:w-[450px] h-[65dvh] md:h-full' : 'w-0'
           }`}
         >
-          {isSidebarOpen && (
+        {/* ✅ MODIFICADO: ternario que alterna entre filtro de precio y resultados */}
+        {isPriceFilterOpen ? (
+          // Vista del filtro de precio — reemplaza temporalmente los resultados
+          <PriceFilterSidebar
+            isOpen={isPriceFilterOpen}
+            onClose={() => {
+              setIsPriceFilterOpen(false) // cierra el filtro
+              setIsSidebarOpen(true)      // asegura que el aside siga visible
+            }}
+          />
+        ) : (
+          isSidebarOpen && (
             <div className="flex flex-col h-full min-h-0">
               <div className="p-4 bg-white shrink-0">
                 <div className="flex justify-between items-center mb-4">
@@ -775,6 +792,7 @@ function BusquedaMapaContent() {
               {renderListPaginationFooter()}
               </div>
             </div>
+            )  
           )}
         </aside>
 

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -25,6 +25,7 @@ interface FilterBarProps {
     updatedAt: string
   }) => void
   variant?: 'home' | 'map'
+  onOpenPriceFilter?: () => void
 }
 
 type LocationValue =
@@ -40,16 +41,18 @@ type LocationValue =
 const MockFilterBtn = ({
   icon: Icon,
   text,
-  hasChevron = true
+  hasChevron = true,
+  onClick
 }: {
   icon?: any
   text: string
   hasChevron?: boolean
+  onClick?: () => void
 }) => (
   <button
     type="button"
     className="h-[36px] flex items-center justify-between bg-white border border-stone-200 text-stone-600 px-3 rounded-xl shadow-sm hover:border-stone-300 transition-all font-inter text-sm whitespace-nowrap gap-2 shrink-0 focus:outline-none cursor-default"
-    onClick={(e) => e.preventDefault()}
+     onClick={(e) => { e.preventDefault(); if (onClick) onClick() }}
   >
     <div className="flex items-center gap-2">
       {Icon && <Icon className="w-4 h-4 text-stone-500" />}
@@ -59,7 +62,7 @@ const MockFilterBtn = ({
   </button>
 )
 
-export default function FilterBar({ onSearch, variant = 'home' }: FilterBarProps) {
+export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilter }: FilterBarProps) {
   const router = useRouter()
 
   const { updateFilters } = useSearchFilters()
@@ -190,7 +193,7 @@ options={['Casa', 'Departamento', 'Terreno', 'Cuarto', 'Espacios', 'Cementerio']
         {variant === 'map' && (
           <div className="flex items-center gap-3 flex-1 overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             <div className="shrink-0">
-              <MockFilterBtn icon={DollarSign} text="Precio" />
+              <MockFilterBtn icon={DollarSign} text="Precio" onClick={onOpenPriceFilter} />
             </div>
             <div className="shrink-0">
               <MockFilterBtn icon={Users} text="Capacidad" />

--- a/frontend/src/components/filters/PriceFilterSidebar.tsx
+++ b/frontend/src/components/filters/PriceFilterSidebar.tsx
@@ -54,15 +54,15 @@ export default function PriceFilterSidebar({ isOpen, onClose }: PriceFilterSideb
   }
 
   return (
-    <div className="flex flex-col gap-8 p-6 w-full max-w-[350px] bg-white h-full border-r border-stone-200">
+    <div className="flex flex-col gap-8 p-6 w-full bg-white h-full overflow-y-auto">
       <div>
-        <h3 className="font-bold text-sm text-stone-800 uppercase tracking-wide mb-1">
+        <h3 className="font-bold text-sm text-stone-800 uppercase tracking-wide mb-1 text-center">
           Filtrar por Precio
         </h3>
-        <p className="text-sm text-stone-500 mb-4">Seleccione el tipo de moneda:</p>
+        <p className="text-sm text-stone-500 mb-4 text-center">Seleccione el tipo de moneda:</p>
 
         {/* Toggle de Moneda */}
-        <div className="flex bg-stone-100 rounded-full p-1 w-fit mb-6 shadow-inner">
+        <div className="flex bg-stone-100 rounded-full p-1 w-fit mb-6 shadow-inner mx-auto">
           <button
             onClick={() => setMoneda('BOB')}
             className={`px-6 py-2 rounded-full text-sm font-bold transition-all ${


### PR DESCRIPTION
## 📋 Descripción
Integra `PriceFilterSidebar` en la página `busqueda_mapa` y conecta el botón 
"Precio" del `FilterBar` para abrir el filtro dentro del panel lateral izquierdo.

## ✅ Cambios incluidos

**`FilterBar.tsx`**
- Agrega prop `onOpenPriceFilter?: () => void` a la interface
- Conecta el prop al componente `MockFilterBtn` de Precio mediante `onClick`

**`busqueda_mapa/page.tsx`**
- Importa `PriceFilterSidebar`
- Agrega estado `isPriceFilterOpen` para controlar visibilidad
- Conecta `onOpenPriceFilter` al `FilterBar` del render desktop
- El `aside` ahora usa ternario: muestra `PriceFilterSidebar` O los resultados, nunca ambos

**`PriceFilterSidebar.tsx`** (fix estético)
- Elimina `border-r` que generaba línea negra visible en el aside
- Elimina `max-w-[350px]` para que ocupe todo el ancho del aside
- Centra el toggle $BOB/$USD y el título con `mx-auto` y `text-center`

## 🚫 Fuera del alcance de este PR
- Integración en render móvil (Bottom Sheet) — PR futuro
- Validaciones de min > max y negativos — Día 2
- Slider dual thumb — Día 3

## 🧪 Lint
`pnpm lint:front` → **0 errors**  
Las 111 warnings son preexistentes, ninguna pertenece a los archivos de este PR.

## 📁 Archivos modificados
- `frontend/src/app/busqueda_mapa/page.tsx`
- `frontend/src/components/filters/FilterBar.tsx`
- `frontend/src/components/filters/PriceFilterSidebar.tsx` ← fix visual