### PR TITLE
fix: mejora de reglas de negocio en terrenos y unificación UI de filtros

### DIFF
--- a/backend/src/modules/zonas/zonas.repository.ts
+++ b/backend/src/modules/zonas/zonas.repository.ts
@@ -2,7 +2,7 @@ import { prisma } from "../../lib/prisma.client.js";
 
 export const zonasRepository = {
   async getAll() {
-    return prisma.zonaPredefinida.findMany({
+    return prisma.zona_predefinida.findMany({
       where: { activa: true },
       orderBy: { id: "asc" },
     });

--- a/backend/src/modules/zonas/zonas.repository.ts
+++ b/backend/src/modules/zonas/zonas.repository.ts
@@ -2,7 +2,7 @@ import { prisma } from "../../lib/prisma.client.js";
 
 export const zonasRepository = {
   async getAll() {
-    return prisma.zona_predefinida.findMany({
+    return prisma.zonaPredefinida.findMany({
       where: { activa: true },
       orderBy: { id: "asc" },
     });

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -9,7 +9,11 @@ import {
   Maximize,
   Award,
   SlidersHorizontal,
-  ChevronDown
+  ChevronDown,
+  Building, 
+  Bed,      
+  Trees,    
+  Flower2   
 } from 'lucide-react'
 import { useSearchFilters } from '@/hooks/useSearchFilters'
 import { LocationSearch } from '../layout/LocationSearch'
@@ -86,14 +90,22 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
     }
   }, [])
 
+  const propertyTypes = [
+    { label: 'Casas', icon: Home },
+    { label: 'Departamentos', icon: Building },
+    { label: 'Cuartos', icon: Bed },
+    { label: 'Terrenos', icon: Trees },
+    { label: 'Espacios Cementerio', icon: Flower2 }
+  ]
+
   const handleSearch = (e?: React.FormEvent) => {
     if (e) e.preventDefault()
     const tipoMap: Record<string, string> = {
-      Casa: 'CASA',
-      Departamento: 'DEPARTAMENTO',
-      Terreno: 'TERRENO',
-      Cuarto: 'CUARTO',
-      Cementerio: 'TERRENO_MORTUORIO'
+      Casas: 'CASA',
+      Departamentos: 'DEPARTAMENTO',
+      Terrenos: 'TERRENO',
+      Cuartos: 'CUARTO',
+      "Espacios Cementerio": 'TERRENO_MORTUORIO'
     }
 
     const tipoFinal =
@@ -176,7 +188,7 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
             label={variant === 'map' ? '' : 'Tipo'}
             placeholder="Cualquier tipo"
             icon={Home}
-options={['Casa', 'Departamento', 'Terreno', 'Cuarto', 'Espacios', 'Cementerio']}
+            options={propertyTypes}
             onChange={(val: string) => setTipoInmueble(val)}
             value={tipoInmueble}
           />

--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -93,17 +93,24 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
       Departamento: 'DEPARTAMENTO',
       Terreno: 'TERRENO',
       Cuarto: 'CUARTO',
-      Espacios: 'ESPACIOS',
-      Cementerio: 'CEMENTERIO'
+      Cementerio: 'TERRENO_MORTUORIO'
     }
 
     const tipoFinal =
       tipoMap[tipoInmueble] ||
       (tipoInmueble !== 'Cualquier tipo' ? tipoInmueble.toUpperCase() : null)
 
+    const esTerreno = tipoFinal === 'TERRENO' || tipoFinal === 'TERRENO_MORTUORIO';
+
+    if (esTerreno) {
+      setModosSeleccionados(['VENTA']);
+    }
+
+    const modosFinales = esTerreno ? ['VENTA'] : modosSeleccionados;
+
     const nuevosFiltros = {
       tipoInmueble: tipoFinal ? [tipoFinal] : [],
-      modoInmueble: modosSeleccionados,
+      modoInmueble: modosFinales,
       query: ubicacionTexto,
       updatedAt: new Date().toISOString()
     }


### PR DESCRIPTION
Este PR soluciona un bug lógico en el buscador y mejora la coherencia visual de la plataforma. Se implementaron validaciones de extremo a extremo para garantizar que los terrenos (y terrenos mortuorios) operen exclusivamente en modalidad de "Venta", y se unificó el diseño del selector de inmuebles.

* **Reglas de Negocio Estrictas (`properties.repository` & `validator`):** Se interceptan y bloquean peticiones contradictorias (ej. buscar "Terrenos en Alquiler"). Ahora el sistema fuerza automáticamente la modalidad "VENTA" para los terrenos desde la UI hasta la consulta a la BD.
* **Nuevas Categorías:** Se integró soporte completo para `CUARTO` y `TERRENO_MORTUORIO` en los validadores de creación.
* **Unificación de UI (`FilterBar.tsx`):** El dropdown de "Tipo de Inmueble" ahora coincide exactamente con el diseño de la vista principal. Se agregaron íconos de Lucide, opciones en plural (*Casas, Departamentos*) y se mapeó correctamente la opción unificada "Espacios Cementerio".
* **Linter & Clean Code:** Se refactorizó la lógica del `FilterBar` eliminando variables mutables (`let`) para cumplir con las exigencias de seguridad de ESLint.