### PR TITLE
HU3 Backend: implementar service y controller de resumen final de publicación

### DIFF
--- a/backend/src/modules/publicacion/publicacion.controller.ts
+++ b/backend/src/modules/publicacion/publicacion.controller.ts
@@ -3,6 +3,7 @@ import {
   eliminarPublicacionService,
   listarMisPublicacionesService,
   editarPublicacionService,
+  obtenerResumenFinalService,
 } from "./publicacion.service.js";
 
 interface AuthRequest extends Request {
@@ -46,6 +47,68 @@ export const listarMisPublicacionesController = async (
   }
 };
 
+export const obtenerResumenFinalController = async (
+  req: AuthRequest,
+  res: Response,
+) => {
+  const publicacionId = Number(req.params.id);
+  const usuarioSolicitanteId = req.user?.id;
+
+  try {
+    const resumen = await obtenerResumenFinalService(
+      publicacionId,
+      Number(usuarioSolicitanteId),
+    );
+
+    return res.status(200).json({
+      ok: true,
+      data: resumen,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      switch (error.message) {
+        case "ID_INVALIDO":
+          return res.status(400).json({
+            ok: false,
+            message: "El id de la publicación es inválido",
+          });
+
+        case "USUARIO_INVALIDO":
+          return res.status(401).json({
+            ok: false,
+            message: "Usuario no autenticado",
+          });
+
+        case "PUBLICACION_NO_EXISTE":
+          return res.status(404).json({
+            ok: false,
+            message: "La publicación no existe",
+          });
+
+        case "NO_AUTORIZADO":
+          return res.status(403).json({
+            ok: false,
+            message:
+              "No puede acceder al resumen final de una publicación de otro usuario",
+          });
+
+        case "PUBLICACION_YA_ELIMINADA":
+          return res.status(409).json({
+            ok: false,
+            message: "La publicación ya fue eliminada",
+          });
+      }
+    }
+
+    console.error("Error al obtener resumen final de la publicación:", error);
+
+    return res.status(500).json({
+      ok: false,
+      message: "No se pudo obtener el resumen final de la publicación",
+    });
+  }
+};
+
 export const editarPublicacionController = async (
   req: AuthRequest,
   res: Response,
@@ -73,20 +136,59 @@ export const editarPublicacionController = async (
             ok: false,
             message: "El id de la publicación es inválido",
           });
+
         case "USUARIO_INVALIDO":
           return res.status(401).json({
             ok: false,
             message: "Usuario no autenticado",
           });
+
         case "PUBLICACION_NO_EXISTE":
           return res.status(404).json({
             ok: false,
             message: "La publicación no existe",
           });
+
         case "NO_AUTORIZADO":
           return res.status(403).json({
             ok: false,
             message: "No puede editar publicaciones de otros usuarios",
+          });
+
+        case "PUBLICACION_YA_ELIMINADA":
+          return res.status(409).json({
+            ok: false,
+            message: "La publicación ya fue eliminada",
+          });
+
+        case "TITULO_INVALIDO":
+          return res.status(400).json({
+            ok: false,
+            message: "El título ingresado es inválido",
+          });
+
+        case "DESCRIPCION_INVALIDA":
+          return res.status(400).json({
+            ok: false,
+            message: "La descripción ingresada es inválida",
+          });
+
+        case "TIPO_ACCION_INVALIDO":
+          return res.status(400).json({
+            ok: false,
+            message: "El tipo de operación ingresado es inválido",
+          });
+
+        case "UBICACION_INVALIDA":
+          return res.status(400).json({
+            ok: false,
+            message: "La ubicación ingresada es inválida",
+          });
+
+        case "PRECIO_INVALIDO":
+          return res.status(400).json({
+            ok: false,
+            message: "El precio ingresado es inválido",
           });
       }
     }
@@ -126,21 +228,25 @@ export const eliminarPublicacionController = async (
             ok: false,
             message: "El id de la publicación es inválido",
           });
+
         case "USUARIO_INVALIDO":
           return res.status(401).json({
             ok: false,
             message: "Usuario no autenticado",
           });
+
         case "PUBLICACION_NO_EXISTE":
           return res.status(404).json({
             ok: false,
             message: "La publicación no existe",
           });
+
         case "NO_AUTORIZADO":
           return res.status(403).json({
             ok: false,
             message: "No puede eliminar publicaciones de otros usuarios",
           });
+
         case "PUBLICACION_YA_ELIMINADA":
           return res.status(409).json({
             ok: false,

--- a/backend/src/modules/publicacion/publicacion.routes.ts
+++ b/backend/src/modules/publicacion/publicacion.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { requireAuth } from "../../middleware/auth.middleware.js";
 import {
   listarMisPublicacionesController,
+  obtenerResumenFinalController,
   editarPublicacionController,
   eliminarPublicacionController,
 } from "./publicacion.controller.js";
@@ -9,6 +10,7 @@ import {
 const router = Router();
 
 router.get("/mias", requireAuth, listarMisPublicacionesController);
+router.get("/:id/resumen-final", requireAuth, obtenerResumenFinalController);
 router.put("/:id", requireAuth, editarPublicacionController);
 router.delete("/:id", requireAuth, eliminarPublicacionController);
 

--- a/backend/src/modules/publicacion/publicacion.service.ts
+++ b/backend/src/modules/publicacion/publicacion.service.ts
@@ -1,9 +1,110 @@
 import {
   buscarPublicacionesPorUsuarioRepository,
   buscarPublicacionPorIdRepository,
+  buscarResumenFinalPorIdRepository,
   actualizarPublicacionRepository,
   eliminarLogicamentePublicacionRepository,
 } from "./publicacion.repository.js";
+
+type TipoAccionPermitido = "VENTA" | "ALQUILER" | "ANTICRETO";
+
+type EditarPublicacionInput = {
+  titulo?: unknown;
+  title?: unknown;
+  descripcion?: unknown;
+  details?: unknown;
+  tipoAccion?: unknown;
+  operationType?: unknown;
+  ubicacion?: unknown;
+  location?: unknown;
+  precio?: unknown;
+  price?: unknown;
+};
+
+type ResumenFinalRepositoryResult = NonNullable<
+  Awaited<ReturnType<typeof buscarResumenFinalPorIdRepository>>
+>;
+
+type ParametroPersonalizadoDb =
+  ResumenFinalRepositoryResult["inmueble"] extends {
+    inmueble_etiqueta: Array<infer T>;
+  }
+    ? T
+    : never;
+
+type MultimediaDb =
+  ResumenFinalRepositoryResult["multimedia"] extends Array<infer T>
+    ? T
+    : never;
+
+type ParametroPersonalizadoResumen = {
+  id: number;
+  nombre: string;
+};
+
+type MultimediaResumen = {
+  id: number;
+  url: string;
+  tipo: string;
+  pesoMb: number | null;
+};
+
+const ESTADO_PUBLICACION_ELIMINADA = "ELIMINADA";
+const TIPO_MULTIMEDIA_IMAGEN = "IMAGEN";
+const TIPO_MULTIMEDIA_VIDEO = "VIDEO";
+const TIPOS_ACCION_VALIDOS: TipoAccionPermitido[] = [
+  "VENTA",
+  "ALQUILER",
+  "ANTICRETO",
+];
+
+const normalizarTexto = (valor: unknown) => String(valor ?? "").trim();
+
+const normalizarTipoMultimedia = (tipo: unknown) =>
+  normalizarTexto(tipo).toUpperCase();
+
+const esNumeroPositivo = (valor: unknown) => {
+  if (valor === undefined || valor === null || valor === "") {
+    return false;
+  }
+
+  const numero = Number(valor);
+  return !Number.isNaN(numero) && numero > 0;
+};
+
+const obtenerTipoAccionNormalizado = (
+  valor: unknown,
+): TipoAccionPermitido | null => {
+  const tipoAccion = normalizarTexto(valor).toUpperCase();
+
+  if (!tipoAccion) {
+    return null;
+  }
+
+  return TIPOS_ACCION_VALIDOS.includes(tipoAccion as TipoAccionPermitido)
+    ? (tipoAccion as TipoAccionPermitido)
+    : null;
+};
+
+const obtenerPrimeraImagenUrl = (
+  multimedia:
+    | Array<{
+        url: string;
+        tipo?: unknown;
+      }>
+    | null
+    | undefined,
+) => {
+  if (!multimedia || multimedia.length === 0) {
+    return null;
+  }
+
+  const primeraImagen = multimedia.find(
+    (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN,
+  );
+
+  return primeraImagen?.url ?? null;
+};
 
 export const listarMisPublicacionesService = async (usuarioId: number) => {
   if (Number.isNaN(usuarioId) || usuarioId <= 0) {
@@ -25,17 +126,19 @@ export const listarMisPublicacionesService = async (usuarioId: number) => {
       publicacion.inmueble.ubicacion?.direccion || "Ubicación no disponible",
     nroBanos: publicacion.inmueble.nroBanos,
     nroCuartos: publicacion.inmueble.nroCuartos,
-    superficieM2: publicacion.inmueble.superficieM2
-      ? Number(publicacion.inmueble.superficieM2)
-      : null,
-    imagenUrl: publicacion.multimedia?.[0]?.url ?? null,
+    superficieM2:
+      publicacion.inmueble.superficieM2 !== null &&
+      publicacion.inmueble.superficieM2 !== undefined
+        ? Number(publicacion.inmueble.superficieM2)
+        : null,
+    imagenUrl: obtenerPrimeraImagenUrl(publicacion.multimedia),
   }));
 };
 
 export const editarPublicacionService = async (
   publicacionId: number,
   usuarioSolicitanteId: number,
-  data: any,
+  data: EditarPublicacionInput,
 ) => {
   if (Number.isNaN(publicacionId) || publicacionId <= 0) {
     throw new Error("ID_INVALIDO");
@@ -55,40 +158,77 @@ export const editarPublicacionService = async (
     throw new Error("NO_AUTORIZADO");
   }
 
+  if (publicacion.estado === ESTADO_PUBLICACION_ELIMINADA) {
+    throw new Error("PUBLICACION_YA_ELIMINADA");
+  }
+
   const titulo = data?.titulo ?? data?.title;
   const descripcion = data?.descripcion ?? data?.details;
   const tipoAccion = data?.tipoAccion ?? data?.operationType;
   const ubicacion = data?.ubicacion ?? data?.location;
   const precioRaw = data?.precio ?? data?.price;
 
-  if (titulo !== undefined && !String(titulo).trim()) {
+  if (titulo !== undefined && !normalizarTexto(titulo)) {
     throw new Error("TITULO_INVALIDO");
   }
 
-  if (descripcion !== undefined && !String(descripcion).trim()) {
+  if (descripcion !== undefined && !normalizarTexto(descripcion)) {
     throw new Error("DESCRIPCION_INVALIDA");
   }
 
-  if (tipoAccion !== undefined && !String(tipoAccion).trim()) {
-    throw new Error("TIPO_ACCION_INVALIDO");
+  if (ubicacion !== undefined && !normalizarTexto(ubicacion)) {
+    throw new Error("UBICACION_INVALIDA");
   }
 
-  if (ubicacion !== undefined && !String(ubicacion).trim()) {
-    throw new Error("UBICACION_INVALIDA");
+  if (tipoAccion !== undefined) {
+    const tipoAccionNormalizado = obtenerTipoAccionNormalizado(tipoAccion);
+
+    if (!tipoAccionNormalizado) {
+      throw new Error("TIPO_ACCION_INVALIDO");
+    }
   }
 
   if (
     precioRaw !== undefined &&
     precioRaw !== null &&
     precioRaw !== "" &&
-    (Number.isNaN(Number(precioRaw)) || Number(precioRaw) <= 0)
+    !esNumeroPositivo(precioRaw)
   ) {
     throw new Error("PRECIO_INVALIDO");
   }
 
+  const payloadNormalizado: Record<string, unknown> = {
+    ...(data as Record<string, unknown>),
+  };
+
+  if (titulo !== undefined) {
+    payloadNormalizado.titulo = normalizarTexto(titulo);
+  }
+
+  if (descripcion !== undefined) {
+    payloadNormalizado.descripcion = normalizarTexto(descripcion);
+  }
+
+  if (ubicacion !== undefined) {
+    payloadNormalizado.ubicacion = normalizarTexto(ubicacion);
+  }
+
+  if (tipoAccion !== undefined) {
+    payloadNormalizado.tipoAccion = obtenerTipoAccionNormalizado(tipoAccion);
+  }
+
+  if (
+    precioRaw !== undefined &&
+    precioRaw !== null &&
+    precioRaw !== "" &&
+    esNumeroPositivo(precioRaw)
+  ) {
+    payloadNormalizado.precio = Number(precioRaw);
+  }
+
   const actualizada = await actualizarPublicacionRepository(
     publicacionId,
-    data,
+    payloadNormalizado,
   );
 
   return {
@@ -99,7 +239,7 @@ export const editarPublicacionService = async (
     tipoAccion: actualizada.inmueble.tipoAccion,
     ubicacion:
       actualizada.inmueble.ubicacion?.direccion || "Ubicación no disponible",
-    imagenUrl: actualizada.multimedia?.[0]?.url ?? null,
+    imagenUrl: obtenerPrimeraImagenUrl(actualizada.multimedia),
   };
 };
 
@@ -125,7 +265,7 @@ export const eliminarPublicacionService = async (
     throw new Error("NO_AUTORIZADO");
   }
 
-  if (publicacion.estado === "ELIMINADA") {
+  if (publicacion.estado === ESTADO_PUBLICACION_ELIMINADA) {
     throw new Error("PUBLICACION_YA_ELIMINADA");
   }
 
@@ -136,6 +276,121 @@ export const eliminarPublicacionService = async (
 
   return {
     id: publicacion.id,
-    estado: "ELIMINADA",
+    estado: ESTADO_PUBLICACION_ELIMINADA,
+  };
+};
+
+export const obtenerResumenFinalService = async (
+  publicacionId: number,
+  usuarioSolicitanteId: number,
+) => {
+  if (Number.isNaN(publicacionId) || publicacionId <= 0) {
+    throw new Error("ID_INVALIDO");
+  }
+
+  if (Number.isNaN(usuarioSolicitanteId) || usuarioSolicitanteId <= 0) {
+    throw new Error("USUARIO_INVALIDO");
+  }
+
+  const resumen = await buscarResumenFinalPorIdRepository(publicacionId);
+
+  if (!resumen) {
+    throw new Error("PUBLICACION_NO_EXISTE");
+  }
+
+  if (resumen.usuarioId !== usuarioSolicitanteId) {
+    throw new Error("NO_AUTORIZADO");
+  }
+
+  if (resumen.estado === ESTADO_PUBLICACION_ELIMINADA) {
+    throw new Error("PUBLICACION_YA_ELIMINADA");
+  }
+
+  const parametrosPersonalizados: ParametroPersonalizadoResumen[] =
+    (resumen.inmueble?.inmueble_etiqueta ?? []).map(
+      (item: ParametroPersonalizadoDb) => ({
+        id: item.etiqueta.id,
+        nombre: item.etiqueta.nombre,
+      }),
+    );
+
+  const parametrosUnicos = parametrosPersonalizados.filter(
+    (
+      parametro: ParametroPersonalizadoResumen,
+      index: number,
+      array: ParametroPersonalizadoResumen[],
+    ) => array.findIndex((item) => item.id === parametro.id) === index,
+  );
+
+  const multimedia: MultimediaResumen[] = (resumen.multimedia ?? []).map(
+    (item: MultimediaDb) => ({
+      id: item.id,
+      url: item.url,
+      tipo: normalizarTipoMultimedia(item.tipo),
+      pesoMb:
+        item.pesoMb !== null && item.pesoMb !== undefined
+          ? Number(item.pesoMb)
+          : null,
+    }),
+  );
+
+  const imagenes = multimedia.filter(
+    (item: MultimediaResumen) => item.tipo === TIPO_MULTIMEDIA_IMAGEN,
+  );
+
+  const videos = multimedia.filter(
+    (item: MultimediaResumen) => item.tipo === TIPO_MULTIMEDIA_VIDEO,
+  );
+
+  return {
+    id: resumen.id,
+    publicacionId: resumen.id,
+    inmuebleId: resumen.inmuebleId,
+
+    publicacion: {
+      titulo: resumen.titulo ?? resumen.inmueble?.titulo ?? null,
+      descripcion:
+        resumen.descripcion ?? resumen.inmueble?.descripcion ?? null,
+      estado: resumen.estado,
+      fechaPublicacion: resumen.fechaPublicacion,
+    },
+
+    datosGenerales: {
+      tipoOperacion: resumen.inmueble?.tipoAccion ?? null,
+      tipoInmueble: resumen.inmueble?.categoria ?? null,
+      direccion: resumen.inmueble?.ubicacion?.direccion ?? "No especificado",
+      ciudad: resumen.inmueble?.ubicacion?.ciudad ?? "No especificado",
+      zona: resumen.inmueble?.ubicacion?.zona ?? "No especificado",
+      precio:
+        resumen.inmueble?.precio !== null &&
+        resumen.inmueble?.precio !== undefined
+          ? Number(resumen.inmueble.precio)
+          : null,
+      areaM2:
+        resumen.inmueble?.superficieM2 !== null &&
+        resumen.inmueble?.superficieM2 !== undefined
+          ? Number(resumen.inmueble.superficieM2)
+          : null,
+      coordenadas: {
+        latitud: resumen.inmueble?.ubicacion?.latitud ?? null,
+        longitud: resumen.inmueble?.ubicacion?.longitud ?? null,
+      },
+    },
+
+    caracteristicas: {
+      habitaciones: resumen.inmueble?.nroCuartos ?? null,
+      banos: resumen.inmueble?.nroBanos ?? null,
+      estacionamiento: null,
+    },
+
+    parametrosPersonalizados: parametrosUnicos,
+
+    multimedia: {
+      total: multimedia.length,
+      imagenes,
+      videos,
+    },
+
+    soloLectura: true,
   };
 };


### PR DESCRIPTION
## Objetivo
Implementar la base backend para la HU3 del segundo sprint: visualizar el resumen final de una publicación antes de su confirmación.

## Cambios realizados
- Se implementó el service para obtener el resumen final de una publicación.
- Se implementó el controller para exponer la lógica del resumen final.
- Se integró la lectura de datos desde base de datos usando el repository de publicación.
- Se añadieron validaciones y manejo de errores para los casos de:
  - ID inválido
  - usuario no autenticado
  - publicación inexistente
  - acceso no autorizado
  - publicación eliminada
- Se mejoró el manejo de errores de validación en edición de publicación para evitar respuestas 500 innecesarias.
- Se mantuvo la implementación dentro del módulo `publicacion` para no afectar otros módulos del sistema.

## No incluido en este avance
- Rutas finales del resumen y confirmación
- Pruebas HTTP completas del endpoint
- Lógica de confirmación/publicación final

## Observaciones
- La rama fue sincronizada con los cambios recientes de `develop` para mantener compatibilidad con la base actual del proyecto.

## Avance adicional
- Se agregó la ruta `GET /api/publicaciones/:id/resumen-final`.
- La ruta fue protegida con autenticación mediante `requireAuth`.
- Se conectó la ruta con el controller del resumen final dentro del módulo `publicacion`.