### PR TITLE
feat(admin blogs): vista de blogs como administrador y moderacion de posts(HU8)

### DIFF
--- a/frontend/src/app/admin/blogs/[id]/page.tsx
+++ b/frontend/src/app/admin/blogs/[id]/page.tsx
@@ -1,0 +1,9 @@
+import AdminBlogReview from "@/components/blog/admin/AdminBlogReview";
+
+export default function AdminBlogReviewPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  return <AdminBlogReview blogId={params.id} />;
+}

--- a/frontend/src/app/admin/blogs/page.tsx
+++ b/frontend/src/app/admin/blogs/page.tsx
@@ -1,0 +1,5 @@
+import AdminBlogsModeration from "@/components/blog/admin/AdminBlogsModeration";
+
+export default function AdminBlogsPage() {
+  return <AdminBlogsModeration />;
+}

--- a/frontend/src/app/blogs/page.tsx
+++ b/frontend/src/app/blogs/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import BlogCard from "@/components/blog/BlogCard";
 import MyRecentBlogsPanel from "@/components/blog/MyRecentBlogsPanel";
 import BlogFilterChips from "@/components/blog/BlogFilterChips";
 import FeaturedBlogSpotlight from "@/components/blog/FeaturedBlogSpotlight";
 import { useBlogFeed } from "@/hooks/useBlogFeed";
-
-const USER_STORAGE_KEY = "propbol_user";
+import { USER_STORAGE_KEY } from "@/lib/session";
 
 export default function BlogsPage() {
   const {
@@ -22,7 +22,6 @@ export default function BlogsPage() {
   } = useBlogFeed();
 
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-
   useEffect(() => {
     const syncAuthState = () => {
       setIsAuthenticated(Boolean(localStorage.getItem(USER_STORAGE_KEY)));
@@ -41,11 +40,8 @@ export default function BlogsPage() {
   return (
     <div className="min-h-screen bg-[linear-gradient(180deg,#fbf6ef_0%,#f5efe7_45%,#ffffff_100%)]">
       <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-
-        {/* ✅ Panel de blogs recientes (feature/blogsRecientes) */}
         <MyRecentBlogsPanel />
 
-        {/* HEADER */}
         <section className="space-y-6">
           <h1 className="max-w-3xl font-heading text-4xl font-bold leading-tight text-stone-900 sm:text-5xl">
             Perspectivas para el Bien Raiz Moderno.
@@ -60,23 +56,33 @@ export default function BlogsPage() {
               />
             </div>
 
-            <button
-              type="button"
-              disabled={!isAuthenticated}
-              aria-disabled={!isAuthenticated}
-              title={
-                isAuthenticated
-                  ? "La creacion de blogs se habilitara cuando el flujo este integrado."
-                  : "Disponible solo para usuarios registrados."
-              }
-              className={`inline-flex min-h-[54px] items-center justify-center self-start px-8 text-sm font-semibold uppercase tracking-[0.22em] transition-colors lg:self-auto ${
-                isAuthenticated
-                  ? "bg-[#a56400] text-white hover:bg-[#8e5800]"
-                  : "cursor-not-allowed bg-[#a56400] text-white/75 opacity-80"
-              }`}
-            >
-              AÑADIR POST
-            </button>
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              {/* TODO: restringir este acceso por rol cuando se integre backend. */}
+              <Link
+                href="/admin/blogs"
+                className="inline-flex min-h-[54px] items-center justify-center border border-stone-300 px-8 text-sm font-semibold uppercase tracking-[0.22em] text-stone-700 transition-colors hover:border-[#a56400] hover:text-[#a56400]"
+              >
+                Moderar Posts
+              </Link>
+
+              <button
+                type="button"
+                disabled={!isAuthenticated}
+                aria-disabled={!isAuthenticated}
+                title={
+                  isAuthenticated
+                    ? "La creacion de blogs se habilitara cuando el flujo este integrado."
+                    : "Disponible solo para usuarios registrados."
+                }
+                className={`inline-flex min-h-[54px] items-center justify-center self-start px-8 text-sm font-semibold uppercase tracking-[0.22em] transition-colors lg:self-auto ${
+                  isAuthenticated
+                    ? "bg-[#a56400] text-white hover:bg-[#8e5800]"
+                    : "cursor-not-allowed bg-[#a56400] text-white/75 opacity-80"
+                }`}
+              >
+                AÑADIR POST
+              </button>
+            </div>
           </div>
         </section>
 

--- a/frontend/src/components/blog/admin/AdminBlogReview.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogReview.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { CheckCircle2, ChevronLeft, XCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAdminBlogModeration } from "@/hooks/useAdminBlogModeration";
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("es-BO", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+function StatusBanner({
+  status,
+  rejectionComment,
+}: {
+  status: "APROBADO" | "RECHAZADO";
+  rejectionComment: string | null;
+}) {
+  if (status === "APROBADO") {
+    return (
+      <div className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-800">
+        <p className="text-xs font-semibold uppercase tracking-[0.25em]">
+          Estado actual
+        </p>
+        <h2 className="mt-2 text-2xl font-bold">Articulo publicado</h2>
+        <p className="mt-2 text-sm leading-7">
+          Este blog ya fue aprobado en la demo, por lo que no volvera a
+          aparecer en la pestana de pendientes.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-800">
+      <p className="text-xs font-semibold uppercase tracking-[0.25em]">
+        Estado actual
+      </p>
+      <h2 className="mt-2 text-2xl font-bold">Articulo rechazado</h2>
+      <p className="mt-2 text-sm leading-7">
+        Comentario registrado: {rejectionComment || "Sin comentario adicional."}
+      </p>
+    </div>
+  );
+}
+
+export default function AdminBlogReview({ blogId }: { blogId: string }) {
+  const router = useRouter();
+  const { blogs, isReady, updateBlogStatus } = useAdminBlogModeration();
+  const [rejectionComment, setRejectionComment] = useState("");
+  const [formError, setFormError] = useState("");
+
+  const blog = useMemo(
+    () => blogs.find((currentBlog) => currentBlog.id === blogId),
+    [blogId, blogs],
+  );
+
+  if (!isReady) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+        <div className="rounded-[32px] border border-stone-200 bg-white px-6 py-20 text-center text-stone-500 shadow-sm">
+          Cargando articulo...
+        </div>
+      </div>
+    );
+  }
+
+  if (!blog) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        <div className="rounded-[32px] border border-stone-200 bg-white px-6 py-12 text-center shadow-sm">
+          <h1 className="text-3xl font-bold text-stone-900">
+            Blog no encontrado
+          </h1>
+          <p className="mt-3 text-base leading-7 text-stone-600">
+            El articulo solicitado no existe en la demo o fue removido del
+            almacenamiento local.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <Link
+              href="/admin/blogs"
+              className="inline-flex min-h-[50px] items-center justify-center rounded-full bg-stone-900 px-6 text-sm font-semibold uppercase tracking-[0.2em] text-white"
+            >
+              Volver al listado
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleApprove = () => {
+    // TODO: enviar la aprobacion al backend cuando exista moderacion real.
+    updateBlogStatus(blog.id, "APROBADO");
+    router.push("/admin/blogs");
+  };
+
+  const handleReject = () => {
+    if (!rejectionComment.trim()) {
+      setFormError("Agrega un comentario para justificar el rechazo.");
+      return;
+    }
+
+    // TODO: enviar el rechazo y comentario al backend cuando exista moderacion real.
+    updateBlogStatus(blog.id, "RECHAZADO", rejectionComment);
+    router.push("/admin/blogs");
+  };
+
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,#fbf7f1_0%,#ffffff_48%,#fff8f2_100%)]">
+      <article className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+        <Link
+          href="/admin/blogs"
+          className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-stone-500 transition-colors hover:text-stone-900"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Volver al listado
+        </Link>
+
+        <div className="mt-10 rounded-[36px] border border-stone-200 bg-white p-5 shadow-[0_24px_80px_rgba(28,25,23,0.08)] sm:p-8 lg:p-10">
+          <div className="rounded-full bg-indigo-50 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-indigo-700">
+            {blog.category}
+          </div>
+
+          <h1 className="mt-8 max-w-5xl text-4xl font-black leading-none tracking-tight text-stone-950 sm:text-6xl">
+            {blog.title}
+          </h1>
+
+          <div className="mt-10 grid gap-5 border-b border-stone-200 pb-8 text-sm text-stone-600 sm:grid-cols-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">
+                Autor
+              </p>
+              <p className="mt-2 text-lg font-semibold text-stone-900">
+                {blog.authorName}
+              </p>
+              <p>{blog.authorRole}</p>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">
+                Fecha de creacion
+              </p>
+              <p className="mt-2 text-lg font-semibold text-stone-900">
+                {formatDate(blog.submittedAt)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">
+                Tiempo de lectura
+              </p>
+              <p className="mt-2 text-lg font-semibold text-stone-900">
+                {blog.readingTime}
+              </p>
+            </div>
+          </div>
+
+          <div className="relative mt-10 overflow-hidden rounded-[32px]">
+            <Image
+              src={blog.coverImage}
+              alt={blog.title}
+              width={1600}
+              height={980}
+              className="h-auto w-full object-cover"
+              priority
+            />
+          </div>
+
+          <div className="mx-auto mt-10 max-w-4xl space-y-9 text-lg leading-9 text-stone-700">
+            <p className="text-2xl leading-10 text-stone-800">{blog.excerpt}</p>
+            <p className="text-xl leading-9 text-stone-600">{blog.lead}</p>
+
+            {blog.sections.map((section, index) => (
+              <section key={`${blog.id}-${index}`} className="space-y-4">
+                {section.heading && (
+                  <h2 className="text-3xl font-semibold leading-tight text-stone-900">
+                    {section.heading}
+                  </h2>
+                )}
+
+                {section.paragraphs.map((paragraph, paragraphIndex) => (
+                  <p key={`${blog.id}-${index}-${paragraphIndex}`}>{paragraph}</p>
+                ))}
+              </section>
+            ))}
+          </div>
+
+          <div className="mx-auto mt-12 max-w-4xl border-t border-stone-200 pt-8">
+            {blog.status === "PENDIENTE" ? (
+              <div className="space-y-6">
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-semibold uppercase tracking-[0.22em] text-stone-400">
+                    Decision del admin
+                  </p>
+                  <h2 className="text-3xl font-bold text-stone-900">
+                    Revisa antes de publicar
+                  </h2>
+                  <p className="max-w-2xl text-base leading-7 text-stone-600">
+                    Si rechazas el articulo, agrega un comentario claro para que
+                    el autor sepa que debe mejorar.
+                  </p>
+                </div>
+
+                <label className="block">
+                  <span className="mb-2 block text-sm font-medium text-stone-700">
+                    Comentario de rechazo
+                  </span>
+                  <textarea
+                    value={rejectionComment}
+                    onChange={(event) => {
+                      setRejectionComment(event.target.value);
+                      setFormError("");
+                    }}
+                    rows={5}
+                    placeholder="Ejemplo: falta citar fuentes, mejorar estructura o corregir tono editorial."
+                    className="w-full rounded-[24px] border border-stone-300 px-5 py-4 text-sm text-stone-700 outline-none transition focus:border-[#a56400]"
+                  />
+                </label>
+
+                {formError && (
+                  <p className="text-sm font-medium text-rose-600">{formError}</p>
+                )}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                  <button
+                    type="button"
+                    onClick={handleReject}
+                    className="inline-flex min-h-[54px] items-center justify-center gap-2 rounded-full border border-rose-500 px-8 text-sm font-semibold uppercase tracking-[0.2em] text-rose-600 transition-colors hover:bg-rose-50"
+                  >
+                    <XCircle className="h-4 w-4" />
+                    Rechazar
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleApprove}
+                    className="inline-flex min-h-[54px] items-center justify-center gap-2 rounded-full bg-[#d28518] px-8 text-sm font-semibold uppercase tracking-[0.2em] text-white transition-colors hover:bg-[#b66f10]"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Publicar
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <StatusBanner
+                status={blog.status}
+                rejectionComment={blog.rejectionComment}
+              />
+            )}
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { useAdminBlogModeration } from "@/hooks/useAdminBlogModeration";
+import type {
+  AdminModerationBlog,
+  AdminModerationStatus,
+} from "@/types/adminModerationBlog";
+
+const FILTERS: Array<{
+  label: string;
+  value: AdminModerationStatus;
+}> = [
+  { label: "Pendientes", value: "PENDIENTE" },
+  { label: "Aprobados", value: "APROBADO" },
+  { label: "Rechazados", value: "RECHAZADO" },
+];
+
+function formatDate(date: string) {
+  return new Intl.DateTimeFormat("es-BO", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+function getStatusStyles(status: AdminModerationStatus) {
+  if (status === "APROBADO") {
+    return "bg-emerald-50 text-emerald-700";
+  }
+
+  if (status === "RECHAZADO") {
+    return "bg-rose-50 text-rose-700";
+  }
+
+  return "bg-amber-50 text-amber-700";
+}
+
+function EmptyState({ filter }: { filter: AdminModerationStatus }) {
+  const copy =
+    filter === "PENDIENTE"
+      ? "No hay articulos pendientes por revisar."
+      : filter === "APROBADO"
+        ? "Aun no aprobaste articulos en esta vista."
+        : "Todavia no hay articulos rechazados.";
+
+  return (
+    <div className="rounded-[28px] border border-dashed border-stone-300 bg-white px-6 py-14 text-center text-stone-500">
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-stone-400">
+        Sin registros
+      </p>
+      <p className="mt-3 text-base">{copy}</p>
+    </div>
+  );
+}
+
+function BlogRow({ blog }: { blog: AdminModerationBlog }) {
+  const actionLabel = blog.status === "PENDIENTE" ? "Revisar" : "Ver detalle";
+
+  return (
+    <article className="grid gap-4 border-t border-stone-200 px-5 py-5 first:border-t-0 md:grid-cols-[minmax(0,2.6fr)_1.1fr_0.9fr_0.9fr_0.8fr] md:items-center md:px-6">
+      <div className="grid items-start gap-4 md:grid-cols-[4rem_minmax(0,1fr)]">
+        <div className="flex h-16 w-16 shrink-0 items-start justify-start overflow-hidden rounded-2xl shadow-sm">
+          <Image
+            src={blog.coverImage}
+            alt={blog.title}
+            width={64}
+            height={64}
+            className="h-16 w-16 object-cover"
+          />
+        </div>
+
+        <div className="min-w-0 pt-0.5">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-700">
+            {blog.category}
+          </p>
+          <h2 className="mt-2 text-xl font-semibold leading-tight text-stone-900">
+            {blog.title}
+          </h2>
+          <p className="mt-2 text-sm text-stone-500">{blog.excerpt}</p>
+        </div>
+      </div>
+
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-stone-400">
+          Autor
+        </p>
+        <p className="mt-2 text-base font-medium text-stone-700">
+          {blog.authorName}
+        </p>
+        <p className="text-sm text-stone-500">{blog.authorRole}</p>
+      </div>
+
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-stone-400">
+          Fecha
+        </p>
+        <p className="mt-2 text-base font-medium text-stone-700">
+          {formatDate(blog.submittedAt)}
+        </p>
+      </div>
+
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-stone-400">
+          Estado
+        </p>
+        <span
+          className={`mt-2 inline-flex rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${getStatusStyles(blog.status)}`}
+        >
+          {blog.status}
+        </span>
+      </div>
+
+      <div className="flex items-center md:justify-end">
+        <Link
+          href={`/admin/blogs/${blog.id}`}
+          className="inline-flex min-h-[46px] items-center justify-center rounded-full bg-stone-200 px-5 text-sm font-semibold uppercase tracking-[0.18em] text-stone-700 transition-colors hover:bg-stone-900 hover:text-white"
+        >
+          {actionLabel}
+        </Link>
+      </div>
+
+      {blog.status === "RECHAZADO" && blog.rejectionComment && (
+        <div className="rounded-2xl bg-rose-50 px-4 py-3 text-sm text-rose-700 md:col-span-5">
+          <span className="font-semibold">Comentario de rechazo:</span>{" "}
+          {blog.rejectionComment}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function AdminBlogsModeration() {
+  const { blogs, isReady } = useAdminBlogModeration();
+  const [activeFilter, setActiveFilter] =
+    useState<AdminModerationStatus>("PENDIENTE");
+
+  const filteredBlogs = useMemo(
+    () => blogs.filter((blog) => blog.status === activeFilter),
+    [activeFilter, blogs],
+  );
+
+  const counts = useMemo(
+    () =>
+      blogs.reduce<Record<AdminModerationStatus, number>>(
+        (accumulator, blog) => {
+          accumulator[blog.status] += 1;
+          return accumulator;
+        },
+        {
+          PENDIENTE: 0,
+          APROBADO: 0,
+          RECHAZADO: 0,
+        },
+      ),
+    [blogs],
+  );
+
+  if (!isReady) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+        <div className="rounded-[32px] border border-stone-200 bg-white px-6 py-20 text-center text-stone-500 shadow-sm">
+          Cargando panel de moderacion...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,#f8f4ed_0%,#ffffff_50%,#fff8f0_100%)]">
+      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+        <section className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-amber-700">
+              Panel del administrador
+            </p>
+            <h1 className="mt-4 text-4xl font-black tracking-tight text-stone-950 sm:text-5xl">
+              Gestion de Blogs
+            </h1>
+            <p className="mt-5 text-lg leading-8 text-stone-600">
+              Revisa, aprueba o rechaza las ultimas publicaciones de la
+              comunidad inmobiliaria. El estado queda guardado localmente para
+              esta demo mientras no exista integracion con backend.
+            </p>
+            {/* TODO: validar permisos de acceso desde backend cuando exista autenticacion de roles. */}
+          </div>
+
+          <div className="rounded-[28px] border border-stone-200 bg-white p-2 shadow-sm">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              {FILTERS.map((filter) => (
+                <button
+                  key={filter.value}
+                  type="button"
+                  onClick={() => setActiveFilter(filter.value)}
+                  className={`inline-flex min-h-[52px] items-center justify-center rounded-full px-5 text-sm font-semibold uppercase tracking-[0.18em] transition-colors ${
+                    activeFilter === filter.value
+                      ? "bg-[#a56400] text-white"
+                      : "text-stone-500 hover:bg-stone-100 hover:text-stone-800"
+                  }`}
+                >
+                  {filter.label}
+                  <span className="ml-2 rounded-full bg-black/10 px-2 py-0.5 text-[11px]">
+                    {counts[filter.value]}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {filteredBlogs.length > 0 ? (
+          <section className="overflow-hidden rounded-[32px] border border-stone-200 bg-white shadow-[0_20px_70px_rgba(28,25,23,0.08)]">
+            <div className="hidden grid-cols-[minmax(0,2.6fr)_1.1fr_0.9fr_0.9fr_0.8fr] gap-4 bg-stone-100 px-6 py-5 text-xs font-semibold uppercase tracking-[0.24em] text-stone-500 md:grid">
+              <span>Titulo del post</span>
+              <span>Autor</span>
+              <span>Fecha</span>
+              <span>Estado</span>
+              <span className="text-right">Accion</span>
+            </div>
+
+            <div>
+              {filteredBlogs.map((blog) => (
+                <BlogRow key={blog.id} blog={blog} />
+              ))}
+            </div>
+          </section>
+        ) : (
+          <EmptyState filter={activeFilter} />
+        )}
+
+        <div className="flex flex-col gap-3 text-sm text-stone-500 sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-semibold uppercase tracking-[0.18em] text-stone-400">
+            Mostrando {filteredBlogs.length} de {blogs.length} registros
+          </p>
+          <Link
+            href="/blogs"
+            className="inline-flex items-center gap-2 font-semibold uppercase tracking-[0.18em] text-[#a56400]"
+          >
+            Volver a Blogs
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -7,10 +7,10 @@ import Footer from "@/components/layout/Footer";
 import RegisterSuccessToast from "@/components/layout/RegisterSuccessToast";
 import { useInactivityLogout } from "@/hooks/useInactivityLogout";
 import { useAccountStatus } from "@/hooks/useAccountStatus";
+import { buildSessionUser, USER_STORAGE_KEY } from "@/lib/session";
 
 const AUTH_ROUTES = ["/sign-in", "/sign-up"];
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
-const USER_STORAGE_KEY = "propbol_user";
 const SESSION_EXPIRES_KEY = "propbol_session_expires";
 const TOKEN_STORAGE_KEY = "token";
 const SESSION_DURATION_MS = 60 * 60 * 1000;
@@ -96,22 +96,11 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
         const data = await response.json();
 
-        const userName =
-          data.user?.nombre && data.user?.apellido
-            ? `${data.user.nombre} ${data.user.apellido}`
-            : (data.user?.correo ?? "");
-
         localStorage.setItem(
           SESSION_EXPIRES_KEY,
           String(Date.now() + SESSION_DURATION_MS),
         );
-        localStorage.setItem(
-          USER_STORAGE_KEY,
-          JSON.stringify({
-            name: userName,
-            email: data.user?.correo ?? "",
-          }),
-        );
+        localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(buildSessionUser(data.user)));
 
         window.dispatchEvent(new Event("propbol:session-changed"));
       } catch {

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -20,6 +20,7 @@ import NavLinks from "../navbar/NavLinks";
 import UserMenu from "../navbar/UserMenu";
 import LogoutModal from "../navbar/LogoutModal";
 import { useNotifications } from "@/hooks/useNotifications";
+import { buildSessionUser, USER_STORAGE_KEY } from "@/lib/session";
 import type { NotificationFilter } from "@/types/notification";
 
 export type User = {
@@ -28,7 +29,6 @@ export type User = {
   avatar?: string | null;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type MeResponse = {
   message?: string;
   user?: {
@@ -51,7 +51,6 @@ class SessionValidationError extends Error {
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
-const USER_STORAGE_KEY = "propbol_user";
 const SESSION_EXPIRES_KEY = "propbol_session_expires";
 
 const filters: NotificationFilter[] = [
@@ -174,25 +173,9 @@ export default function Navbar() {
     try {
       const validatedUser = await fetchCurrentUser(token);
 
-      const finalName =
-        validatedUser.nombre && validatedUser.apellido
-          ? `${validatedUser.nombre} ${validatedUser.apellido}`
-          : validatedUser.nombre || validatedUser.correo;
+      const finalUser: User = buildSessionUser(validatedUser);
 
-      const finalUser: User = {
-        name: finalName,
-        email: validatedUser.correo,
-        avatar: validatedUser.avatar ?? null,
-      };
-
-      localStorage.setItem(
-        USER_STORAGE_KEY,
-        JSON.stringify({
-          name: finalUser.name,
-          email: finalUser.email,
-          avatar: finalUser.avatar,
-        }),
-      );
+      localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(finalUser));
       localStorage.setItem("nombre", finalUser.name);
       localStorage.setItem("correo", finalUser.email);
       localStorage.setItem("avatar", finalUser.avatar ?? "");

--- a/frontend/src/components/layout/auth/formularioSignIn.tsx
+++ b/frontend/src/components/layout/auth/formularioSignIn.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { buildSessionUser, USER_STORAGE_KEY } from "@/lib/session";
 
 type LoginResponse = {
   message?: string;
@@ -67,7 +68,7 @@ const DEACTIVATED_ACCOUNT_MESSAGE = "Esta cuenta está desactivada";
 
 const clearClientSession = () => {
   localStorage.removeItem("token");
-  localStorage.removeItem("propbol_user");
+  localStorage.removeItem(USER_STORAGE_KEY);
   localStorage.removeItem("propbol_session_expires");
   localStorage.removeItem("nombre");
   localStorage.removeItem("correo");
@@ -88,24 +89,13 @@ const saveSession = (
   },
 ) => {
   localStorage.setItem("token", token);
+  const sessionUser = buildSessionUser(user);
 
-  const userName =
-    user?.nombre && user?.apellido
-      ? `${user.nombre} ${user.apellido}`
-      : user?.nombre || user?.correo || "Usuario";
+  localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(sessionUser));
 
-  localStorage.setItem(
-    "propbol_user",
-    JSON.stringify({
-      name: userName,
-      email: user?.correo ?? "",
-      avatar: user?.avatar ?? null,
-    }),
-  );
-
-  localStorage.setItem("nombre", userName);
-  localStorage.setItem("correo", user?.correo ?? "");
-  localStorage.setItem("avatar", user?.avatar ?? "");
+  localStorage.setItem("nombre", sessionUser.name);
+  localStorage.setItem("correo", sessionUser.email);
+  localStorage.setItem("avatar", sessionUser.avatar ?? "");
   localStorage.setItem(
     "propbol_session_expires",
     String(Date.now() + SESSION_DURATION_MS),

--- a/frontend/src/hooks/useAdminBlogModeration.ts
+++ b/frontend/src/hooks/useAdminBlogModeration.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ADMIN_MODERATION_BLOGS_MOCK } from "@/lib/mock/adminModerationBlogs.mock";
+import type {
+  AdminModerationBlog,
+  AdminModerationStatus,
+} from "@/types/adminModerationBlog";
+
+const ADMIN_BLOGS_STORAGE_KEY = "propbol_admin_moderation_blogs";
+
+function loadStoredBlogs() {
+  if (typeof window === "undefined") {
+    return ADMIN_MODERATION_BLOGS_MOCK;
+  }
+
+  const rawBlogs = localStorage.getItem(ADMIN_BLOGS_STORAGE_KEY);
+
+  if (!rawBlogs) {
+    // TODO: reemplazar este mock local por el listado real cuando exista backend.
+    localStorage.setItem(
+      ADMIN_BLOGS_STORAGE_KEY,
+      JSON.stringify(ADMIN_MODERATION_BLOGS_MOCK),
+    );
+
+    return ADMIN_MODERATION_BLOGS_MOCK;
+  }
+
+  try {
+    return JSON.parse(rawBlogs) as AdminModerationBlog[];
+  } catch {
+    localStorage.setItem(
+      ADMIN_BLOGS_STORAGE_KEY,
+      JSON.stringify(ADMIN_MODERATION_BLOGS_MOCK),
+    );
+
+    return ADMIN_MODERATION_BLOGS_MOCK;
+  }
+}
+
+export function useAdminBlogModeration() {
+  const [blogs, setBlogs] = useState<AdminModerationBlog[]>(
+    ADMIN_MODERATION_BLOGS_MOCK,
+  );
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    const syncBlogs = () => {
+      setBlogs(loadStoredBlogs());
+      setIsReady(true);
+    };
+
+    syncBlogs();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === ADMIN_BLOGS_STORAGE_KEY) {
+        syncBlogs();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const updateBlogStatus = (
+    blogId: string,
+    nextStatus: AdminModerationStatus,
+    rejectionComment?: string,
+  ) => {
+    setBlogs((currentBlogs) => {
+      const updatedBlogs = currentBlogs.map((blog) => {
+        if (blog.id !== blogId) {
+          return blog;
+        }
+
+        return {
+          ...blog,
+          status: nextStatus,
+          rejectionComment:
+            nextStatus === "RECHAZADO" ? rejectionComment?.trim() ?? "" : null,
+          reviewedAt: new Date().toISOString(),
+        };
+      });
+
+      // TODO: persistir aprobacion y rechazo con endpoints reales cuando exista backend.
+      localStorage.setItem(
+        ADMIN_BLOGS_STORAGE_KEY,
+        JSON.stringify(updatedBlogs),
+      );
+
+      return updatedBlogs;
+    });
+  };
+
+  return {
+    blogs,
+    isReady,
+    updateBlogStatus,
+  };
+}

--- a/frontend/src/lib/mock/adminModerationBlogs.mock.ts
+++ b/frontend/src/lib/mock/adminModerationBlogs.mock.ts
@@ -1,0 +1,173 @@
+import type { AdminModerationBlog } from "@/types/adminModerationBlog";
+
+export const ADMIN_MODERATION_BLOGS_MOCK: AdminModerationBlog[] = [
+  {
+    id: "admin-blog-1",
+    title: "Las 10 mejores inversiones en Santa Cruz",
+    category: "Mercado inmobiliario",
+    authorName: "Carlos Mendoza",
+    authorRole: "Autor invitado",
+    submittedAt: "2026-10-24T09:00:00.000Z",
+    readingTime: "8 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1460317442991-0ec209397118?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Un repaso por zonas emergentes, tipologias con mejor retorno y senales de demanda sostenida para el cierre de gestion.",
+    lead:
+      "Santa Cruz mantiene un ritmo de crecimiento que vuelve especialmente atractivas las inversiones residenciales y mixtas en corredores con alta conectividad.",
+    sections: [
+      {
+        heading: "Por que Santa Cruz sigue liderando",
+        paragraphs: [
+          "El dinamismo economico de la ciudad impulsa nuevos desarrollos y una demanda constante por vivienda, oficinas y espacios flexibles.",
+          "Los compradores valoran proyectos con acceso rapido, servicios consolidados y un lenguaje arquitectonico contemporaneo que eleve la percepcion de valor.",
+        ],
+      },
+      {
+        heading: "Zonas a observar en 2026",
+        paragraphs: [
+          "Equipetrol ampliado, Urubo y ciertos sectores del norte muestran una mezcla saludable entre plusvalia, absorcion y oferta diferenciada.",
+          "La clave para el inversionista es detectar proyectos con narrativa clara de producto y no solo competir por precio.",
+        ],
+      },
+    ],
+    status: "PENDIENTE",
+    rejectionComment: null,
+    reviewedAt: null,
+  },
+  {
+    id: "admin-blog-2",
+    title: "Tendencias de Arquitectura 2024",
+    category: "Arquitectura",
+    authorName: "Lucia Fernandez",
+    authorRole: "Colaboradora",
+    submittedAt: "2026-10-23T09:00:00.000Z",
+    readingTime: "6 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1511818966892-d7d671e672a2?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Materiales honestos, espacios serenos y eficiencia energetica se combinan para definir una nueva sensibilidad urbana.",
+    lead:
+      "La arquitectura contemporanea esta abandonando el exceso ornamental para priorizar luz natural, proporciones limpias y experiencia espacial.",
+    sections: [
+      {
+        paragraphs: [
+          "El minimalismo calido gana terreno gracias a interiores que combinan concreto visto, madera y textiles de alta textura.",
+          "Las soluciones modulares y la ventilacion cruzada vuelven a ocupar un lugar central en proyectos de vivienda y hoteleria.",
+        ],
+      },
+      {
+        heading: "Una estetica con criterio funcional",
+        paragraphs: [
+          "Las propuestas mas solidas no persiguen solo imagen; tambien mejoran mantenimiento, flexibilidad de uso y rendimiento termico.",
+        ],
+      },
+    ],
+    status: "PENDIENTE",
+    rejectionComment: null,
+    reviewedAt: null,
+  },
+  {
+    id: "admin-blog-3",
+    title: "Guia para compradores primerizos",
+    category: "Educacion financiera",
+    authorName: "Roberto Gomez",
+    authorRole: "Especialista inmobiliario",
+    submittedAt: "2026-10-22T09:00:00.000Z",
+    readingTime: "7 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1600585154526-990dced4db0d?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Una guia clara sobre presupuesto, validacion legal y criterios practicos para tomar una primera decision de compra con mas confianza.",
+    lead:
+      "Comprar la primera propiedad suele venir acompanado de dudas sobre financiamiento, ubicacion y documentacion, por eso la informacion debe ser precisa y aterrizada.",
+    sections: [
+      {
+        paragraphs: [
+          "El primer filtro debe ser el presupuesto real: cuota mensual sostenible, gastos notariales y fondo para mantenimiento.",
+          "Tambien conviene validar el historial del inmueble y revisar si la ubicacion acompana las necesidades familiares o laborales del comprador.",
+        ],
+      },
+    ],
+    status: "PENDIENTE",
+    rejectionComment: null,
+    reviewedAt: null,
+  },
+  {
+    id: "admin-blog-4",
+    title: "Diseno de interiores: minimalismo calido",
+    category: "Interiorismo",
+    authorName: "Sofia Arteaga",
+    authorRole: "Disenadora invitada",
+    submittedAt: "2026-10-21T09:00:00.000Z",
+    readingTime: "5 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1484154218962-a197022b5858?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Como combinar tonos neutros, capas tactiles y piezas funcionales para lograr espacios habitables y sofisticados.",
+    lead:
+      "El minimalismo calido propone bajar el ruido visual sin renunciar a la sensacion de hogar, usando materiales nobles y una composicion contenida.",
+    sections: [
+      {
+        paragraphs: [
+          "La seleccion de mobiliario prioriza lineas limpias, almacenamiento discreto y circulacion generosa.",
+          "La iluminacion indirecta y los acentos organicos ayudan a construir profundidad sin recargar el ambiente.",
+        ],
+      },
+    ],
+    status: "PENDIENTE",
+    rejectionComment: null,
+    reviewedAt: null,
+  },
+  {
+    id: "admin-blog-5",
+    title: "Como preparar una propiedad para fotografia profesional",
+    category: "Marketing inmobiliario",
+    authorName: "Valeria Paredes",
+    authorRole: "Editora",
+    submittedAt: "2026-10-19T09:00:00.000Z",
+    readingTime: "4 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Orden visual, luz y puesta en escena pueden cambiar por completo la percepcion de valor de una propiedad publicada.",
+    lead:
+      "Una buena sesion fotografica comienza mucho antes de encender la camara: limpieza, estilismo ligero y recorrido narrativo son decisivos.",
+    sections: [
+      {
+        paragraphs: [
+          "Cuando la propiedad comunica amplitud, mantenimiento y claridad funcional, los anuncios elevan su tasa de interes de forma inmediata.",
+        ],
+      },
+    ],
+    status: "APROBADO",
+    rejectionComment: null,
+    reviewedAt: "2026-10-20T12:15:00.000Z",
+  },
+  {
+    id: "admin-blog-6",
+    title: "Errores comunes al fijar el precio de venta",
+    category: "Mercado inmobiliario",
+    authorName: "Daniel Roca",
+    authorRole: "Analista",
+    submittedAt: "2026-10-18T09:00:00.000Z",
+    readingTime: "5 min",
+    coverImage:
+      "https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=1600&q=80",
+    excerpt:
+      "Sobrevalorar por expectativa emocional o subvalorar por urgencia son dos fallas que pueden deteriorar toda la estrategia comercial.",
+    lead:
+      "Una publicacion creible parte de un precio consistente con zona, metraje, estado del inmueble y comparables recientes.",
+    sections: [
+      {
+        paragraphs: [
+          "Cuando el precio no dialoga con el mercado, el inmueble pierde traccion y termina compitiendo en desventaja aun despues de rebajas.",
+        ],
+      },
+    ],
+    status: "RECHAZADO",
+    rejectionComment:
+      "El articulo necesita fuentes mas claras y una conclusion accionable antes de publicarse.",
+    reviewedAt: "2026-10-18T18:40:00.000Z",
+  },
+];

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,24 @@
+export const USER_STORAGE_KEY = "propbol_user";
+
+type SessionUserInput = {
+  correo?: string;
+  nombre?: string;
+  apellido?: string;
+  avatar?: string | null;
+};
+
+export type SessionUser = {
+  name: string;
+  email: string;
+  avatar: string | null;
+};
+
+export function buildSessionUser(user?: SessionUserInput): SessionUser {
+  const fullName = [user?.nombre, user?.apellido].filter(Boolean).join(" ").trim();
+
+  return {
+    name: fullName || user?.correo || "Usuario",
+    email: user?.correo ?? "",
+    avatar: user?.avatar ?? null,
+  };
+}

--- a/frontend/src/types/adminModerationBlog.ts
+++ b/frontend/src/types/adminModerationBlog.ts
@@ -1,0 +1,23 @@
+export type AdminModerationStatus = "PENDIENTE" | "APROBADO" | "RECHAZADO";
+
+export type AdminBlogSection = {
+  heading?: string;
+  paragraphs: string[];
+};
+
+export type AdminModerationBlog = {
+  id: string;
+  title: string;
+  category: string;
+  authorName: string;
+  authorRole: string;
+  submittedAt: string;
+  readingTime: string;
+  coverImage: string;
+  excerpt: string;
+  lead: string;
+  sections: AdminBlogSection[];
+  status: AdminModerationStatus;
+  rejectionComment: string | null;
+  reviewedAt: string | null;
+};


### PR DESCRIPTION
Implementa la vista frontend de moderación de blogs para la HU-08. Se agregó el acceso desde la sección de blogs, un listado mock de posts pendientes/aprobados/rechazados, la vista previa del artículo con acciones de publicar o rechazar, y ajustes de layout para mantener alineado el contenido independientemente de la imagen. Además, se dejó todo como frontend , y comentarios breves en los puntos donde luego deberá integrarse la validación y la lógica del backend.