### PR TITLE
Feature/filter precio

### DIFF
--- a/backend/src/modules/properties/properties.repository.ts
+++ b/backend/src/modules/properties/properties.repository.ts
@@ -111,15 +111,26 @@ export const propertiesRepository = {
       // Fallback: Si no hay texto, asumimos que viene de un botón antiguo de "Ciudades Destacadas"
       where.ubicacion = { ubicacionMaestraId: Number(filtros.locationId) }
     }
-    // ── FILTRO DE PRECIO ───────────────────────────────────────────
+    // ── FILTRO DE PRECIO con conversión de moneda ─────────────────
+    const TASA_CAMBIO_BOB = 6.96 // 1 USD = 6.96 BOB
+
+    let queryMinPrice = filtros.minPrice
+    let queryMaxPrice = filtros.maxPrice
+
+    // Si el usuario busca en BOB, convertimos a USD antes de consultar la BD
     if (filtros.currency) {
-      where.moneda = filtros.currency
-      if (filtros.minPrice != null) {
-        where.precio = { ...((where.precio as object) ?? {}), gte: filtros.minPrice }
+      const monedaUpper = filtros.currency.toUpperCase()
+      if (monedaUpper === 'BOB' || monedaUpper === 'BS') {
+        if (queryMinPrice != null) queryMinPrice = queryMinPrice / TASA_CAMBIO_BOB
+        if (queryMaxPrice != null) queryMaxPrice = queryMaxPrice / TASA_CAMBIO_BOB
       }
-      if (filtros.maxPrice != null) {
-        where.precio = { ...((where.precio as object) ?? {}), lte: filtros.maxPrice }
-      }
+    }
+
+    if (queryMinPrice != null) {
+      where.precio = { ...((where.precio as object) ?? {}), gte: queryMinPrice }
+    }
+    if (queryMaxPrice != null) {
+      where.precio = { ...((where.precio as object) ?? {}), lte: queryMaxPrice }
     }
 
     // ── ORDER BY ───────────────────────────────────────────────────────────

--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -966,6 +966,7 @@ function BusquedaMapaContent() {
               setIsPriceFilterOpen(false) // cierra el filtro
               setIsSidebarOpen(true)      // asegura que el aside siga visible
             }}
+            totalResultados={displayedProperties.length} 
           />
         ) : 
           isSidebarOpen && activeSidebarView === 'results' ? (

--- a/frontend/src/components/filters/PriceFilterSidebar.tsx
+++ b/frontend/src/components/filters/PriceFilterSidebar.tsx
@@ -5,9 +5,10 @@ import { useSearchFilters } from '@/hooks/useSearchFilters'
 import { useRouter, useSearchParams } from 'next/navigation'
 interface PriceFilterSidebarProps {
   isOpen: boolean;  
-  onClose: () => void
+  onClose: () => void;
+  totalResultados?: number;
 }
-export default function PriceFilterSidebar({ isOpen, onClose }: PriceFilterSidebarProps) {  
+export default function PriceFilterSidebar({ isOpen, onClose, totalResultados = -1 }: PriceFilterSidebarProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { updateFilters } = useSearchFilters()
@@ -16,6 +17,7 @@ export default function PriceFilterSidebar({ isOpen, onClose }: PriceFilterSideb
   const [minPrice, setMinPrice] = useState<string>('')
   const [maxPrice, setMaxPrice] = useState<string>('')
   const [error, setError] = useState<string>('')
+  const [filtroAplicado, setFiltroAplicado] = useState(false)  
 
   // Cargar valores iniciales si existen en la URL o SessionStorage
   useEffect(() => {
@@ -59,6 +61,7 @@ export default function PriceFilterSidebar({ isOpen, onClose }: PriceFilterSideb
     params.set('currency', moneda)
 
     router.push(`/busqueda_mapa?${params.toString()}`)
+    setFiltroAplicado(true)
     onClose()
   }
 
@@ -191,6 +194,17 @@ export default function PriceFilterSidebar({ isOpen, onClose }: PriceFilterSideb
           </span>
         </div>
       </div>
+
+      {/* Día 7 - Empty state cuando no hay resultados */}
+      {filtroAplicado && totalResultados === 0 && (
+        <div className="flex flex-col items-center gap-2 py-3 text-center">
+          <span className="text-xl">🔍</span>
+          <p className="text-sm font-semibold text-stone-700">Sin resultados</p>
+          <p className="text-xs text-stone-400">
+            No se encontraron propiedades dentro del rango de precio seleccionado
+          </p>
+        </div>
+      )}
 
       {/* Botón Aplicar */}
       <button


### PR DESCRIPTION
## 📋 Descripción
Fix crítico de conversión de moneda en backend, integración completa del filtro 
de precio con el backend y empty state cuando no hay resultados.
Cubre Días 6 y 7 de la HU2.

## ✅ Cambios incluidos

### Fix backend — conversión de moneda
- `properties.repository.ts`: elimina `where.moneda` (campo inexistente en schema)
- Implementa conversión BOB → USD con tasa 6.96 antes de ejecutar la query en Prisma
- La BD almacena precios solo en USD, el frontend puede buscar en BOB o USD

### Día 6 — Integración ya funcional (sin cambios nuevos)
- `useProperties.ts` ya enviaba todos los searchParams al backend incluyendo
  `minPrice`, `maxPrice`, `currency` automáticamente

### Día 7 — Empty state (`PriceFilterSidebar.tsx` + `page.tsx`)
- Prop `totalResultados` para recibir el conteo de resultados del padre
- Estado `filtroAplicado` para distinguir entre sin filtro y filtro sin resultados
- Mensaje específico cuando el backend retorna vacío con filtro activo
- `page.tsx` pasa `displayedProperties.length` al componente

## 🧪 Lint
`pnpm lint:front` → 0 errors
`pnpm lint:back` → 0 errors

## 📁 Archivos modificados
- `backend/src/modules/properties/properties.repository.ts`
- `frontend/src/components/filters/PriceFilterSidebar.tsx`
- `frontend/src/app/busqueda_mapa/page.tsx`