### PR TITLE
Feature/filter paginacion avanzada

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -702,7 +702,7 @@ function BusquedaMapaContent() {
           setListPageSize(s);
           setListPage(1);
         }}
-        hint={listTotal === 0 && error ? `Error al cargar: ${error}` : null}
+        hint={error ? `Error al cargar: ${error}` : null}
       />
     ) : null;
   };

--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -4,7 +4,15 @@ import { CapacidadSidebar } from '@/components/filters/CapacidadSidebar'
 import MisZonasSidebar from '@/components/map/MisZonasSidebar'
 import { point, polygon } from '@turf/helpers'
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon'
-import { useState, useEffect, useRef, Suspense, useCallback, useMemo } from 'react'
+import {
+  useState,
+  useEffect,
+  useRef,
+  Suspense,
+  useCallback,
+  useMemo,
+  type Ref,
+} from 'react'
 import { useSearchParams, useRouter } from "next/navigation";
 import nextDynamic from 'next/dynamic'
 import {
@@ -484,6 +492,12 @@ function BusquedaMapaContent() {
     if (listPage > listTotalPages) setListPage(listTotalPages);
   }, [listPage, listTotalPages]);
 
+  const listScrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    listScrollRef.current?.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }, [listSafePage, listPageSize, filterResetKey, isPolygonClosed]);
+
   // === 5. ESTADOS VISUALES Y DE CLUSTERS (develop + HU8) ===
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null)
   const [hoveredId, setHoveredId] = useState<string | null>(null)
@@ -593,8 +607,14 @@ function BusquedaMapaContent() {
     </div>
   )
 
-  const PropertyListMobile = ({ onClickItem }: { onClickItem?: (p: any) => void }) => (
-    <div className="flex-1 overflow-y-auto p-4 bg-stone-50 no-scrollbar">
+  const PropertyListMobile = ({
+    onClickItem,
+    listScrollRef,
+  }: {
+    onClickItem?: (p: any) => void;
+    listScrollRef: Ref<HTMLDivElement>;
+  }) => (
+    <div ref={listScrollRef} className="flex-1 overflow-y-auto p-4 bg-stone-50 no-scrollbar">
       {isLoading ? (
         <div className="flex flex-col justify-center items-center h-full text-stone-400 text-sm gap-2">
           <div className="w-8 h-8 border-2 border-orange-500 border-t-transparent rounded-full animate-spin" />{' '}
@@ -752,7 +772,7 @@ function BusquedaMapaContent() {
                 {MenuToggleComponent}
               </div>
               <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-                <PropertyListMobile onClickItem={(p) => setPinnedProperty(p)} />
+                <PropertyListMobile listScrollRef={listScrollRef} onClickItem={(p) => setPinnedProperty(p)} />
                 {renderListPaginationFooter()}
               </div>
             </div>
@@ -950,6 +970,7 @@ function BusquedaMapaContent() {
                 </div>
                 <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
                   <PropertyListMobile
+                    listScrollRef={listScrollRef}
                     onClickItem={(p) => {
                       setPinnedProperty(p)
                       setSheetState('peek')
@@ -1111,6 +1132,7 @@ function BusquedaMapaContent() {
                 {/* Lista de propiedades */}
                 <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
                   <div
+                    ref={listScrollRef as Ref<HTMLDivElement>}
                     className="flex-1 min-h-0 overflow-y-auto p-4 bg-stone-50 no-scrollbar"
                     onMouseEnter={() => setIsHoveringList(true)}
                     onMouseLeave={() => {

--- a/frontend/src/components/galeria/MapaListadoPaginacion.tsx
+++ b/frontend/src/components/galeria/MapaListadoPaginacion.tsx
@@ -30,11 +30,12 @@ export default function MapaListadoPaginacion({
   const showPaginationControls = !disabled && totalPages > 1;
 
   const visiblePages = useMemo(() => {
-  if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1);
+    if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1);
 
     if (safePage <= 4) return [1, 2, 3, 4, 5, "...", totalPages];
-    if (safePage >= totalPages - 3) return [1, "...", totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
-    
+    if (safePage >= totalPages - 3)
+      return [1, "...", totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+
     return [1, "...", safePage - 1, safePage, safePage + 1, "...", totalPages];
   }, [safePage, totalPages]);
 
@@ -51,9 +52,12 @@ export default function MapaListadoPaginacion({
 
             value={pageSize}
             disabled={disabled}
-            onChange={(e) =>
-              onPageSizeChange(Number(e.target.value) as (typeof PAGE_SIZE_OPTIONS)[number])
-            }
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              if ((PAGE_SIZE_OPTIONS as readonly number[]).includes(v)) {
+                onPageSizeChange(v as PageSize);
+              }
+            }}
           >
             {PAGE_SIZE_OPTIONS.map((n) => (
               <option key={n} value={n}>
@@ -65,15 +69,16 @@ export default function MapaListadoPaginacion({
         </label>
         {showPaginationControls ? (
           <div className="flex items-center gap-1 shrink-0" aria-label="Paginación">
-            <button
-              type="button"
-              disabled={safePage <= 1}
-              onClick={() => onPageChange(safePage - 1)}
-              className="p-1.5 rounded-md border border-stone-200 bg-white disabled:opacity-40"
-              aria-label="Página anterior"
-            >
-              <ChevronLeft size={16} />
-            </button>
+            {safePage > 1 ? (
+              <button
+                type="button"
+                onClick={() => onPageChange(safePage - 1)}
+                className="p-1.5 rounded-md border border-stone-200 bg-white"
+                aria-label="Página anterior"
+              >
+                <ChevronLeft size={16} />
+              </button>
+            ) : null}
             <div className="flex items-center gap-1 justify-center no-scrollbar">
               {visiblePages.map((n, idx) => (
                 n === "..." ? (

--- a/frontend/src/components/galeria/MapaListadoPaginacion.tsx
+++ b/frontend/src/components/galeria/MapaListadoPaginacion.tsx
@@ -94,15 +94,16 @@ export default function MapaListadoPaginacion({
                 )
               ))}
             </div>
-            <button
-              type="button"
-              disabled={safePage >= totalPages}
-              onClick={() => onPageChange(safePage + 1)}
-              className="p-1.5 rounded-md border border-stone-200 bg-white disabled:opacity-40"
-              aria-label="Página siguiente"
-            >
-              <ChevronRight size={16} />
-            </button>
+            {safePage < totalPages ? (
+              <button
+                type="button"
+                onClick={() => onPageChange(safePage + 1)}
+                className="p-1.5 rounded-md border border-stone-200 bg-white"
+                aria-label="Página siguiente"
+              >
+                <ChevronRight size={16} />
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
Descripción de los Cambios

Este PR corrige dos fallos críticos en la experiencia de usuario dentro del listado de resultados de PropBol.
1. Corrección de Scroll en Paginación (BUG-001)

    Problema: Al navegar entre páginas, el sistema mantenía la posición del scroll de la página anterior.

    Solución: Se implementó una lógica para reiniciar el scroll al inicio del listado cada vez que el usuario cambia de página.

2. Ajuste de Visibilidad en Controles de Navegación (BUG-002)

    Problema: El botón de "Siguiente página" permanecía visible (aunque deshabilitado) al llegar al final del listado.

    Solución: Se ajustó el renderizado condicional para ocultar el botón de navegación cuando se alcanza la última página de resultados.
