### PR TITLE
feat: corrección de duplicidad y aislamiento del historial de búsqueda por sesión

### DIFF
--- a/backend/src/modules/perfil/historialBusqueda.controller.ts
+++ b/backend/src/modules/perfil/historialBusqueda.controller.ts
@@ -3,19 +3,32 @@ import { prisma } from '../../lib/prisma.client.js';
 
 export const getHistorialBusqueda = async (req: Request, res: Response) => {
     try {
-        const usuarioId = req.user?.id; // Extraído de la sesión del usuario
+        const usuarioId = req.user?.id;
 
         if (!usuarioId) {
             return res.status(401).json({ message: "No autorizado" });
         }
 
+        // Buscamos los últimos registros (traemos más de 10 por si hay duplicados en DB)
         const historial = await prisma.historial_busqueda.findMany({
             where: { usuarioid: usuarioId },
             orderBy: { creadoen: 'desc' },
-            take: 10 
+            take: 50 
         });
 
-        res.json(historial);
+        // Filtramos duplicados en JS para asegurar términos únicos manteniendo el orden cronológico
+        const uniqueHistorial: any[] = [];
+        const seenTerms = new Set();
+
+        for (const item of historial) {
+            if (!seenTerms.has(item.termino)) {
+                seenTerms.add(item.termino);
+                uniqueHistorial.push(item);
+            }
+            if (uniqueHistorial.length >= 10) break;
+        }
+
+        res.json(uniqueHistorial);
     } catch (error) {
         console.error("Error al obtener historial:", error);
         res.status(500).json({ error: "Error al obtener historial de búsqueda" });
@@ -31,6 +44,24 @@ export const guardarBusqueda = async (req: Request, res: Response) => {
             return res.status(400).json({ message: "Usuario o término faltante" });
         }
 
+        // CONTROL DE DUPLICIDAD: Buscar si ya existe el término para este usuario
+        const existing = await prisma.historial_busqueda.findFirst({
+            where: {
+                usuarioid: usuarioId,
+                termino: termino
+            }
+        });
+
+        if (existing) {
+            // Si existe, actualizamos la fecha para que suba en el historial
+            const actualizada = await prisma.historial_busqueda.update({
+                where: { id: existing.id },
+                data: { creadoen: new Date() }
+            });
+            return res.json(actualizada);
+        }
+
+        // Si no existe, creamos uno nuevo
         const nuevaBusqueda = await prisma.historial_busqueda.create({
             data: {
                 usuarioid: usuarioId,

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -56,6 +56,7 @@ const clearSession = () => {
   localStorage.removeItem(USER_STORAGE_KEY);
   localStorage.removeItem(SESSION_EXPIRES_KEY);
   localStorage.removeItem(TOKEN_STORAGE_KEY);
+  localStorage.removeItem("searchHistory");
 };
 
 export default function AppShell({ children }: { children: React.ReactNode }) {

--- a/frontend/src/components/layout/LocationSearch.tsx
+++ b/frontend/src/components/layout/LocationSearch.tsx
@@ -62,67 +62,58 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
     }
   }, [isOpen])
 
-  // --- PERSISTENCIA: Carga Inicial Sincronizada ---
+  // --- PERSISTENCIA: Carga y sincronización con sesión ---
   useEffect(() => {
-    const initHistory = async () => {
-      // 1. Cargar local primero para rapidez visual
-      const saved = localStorage.getItem('searchHistory')
-      if (saved) setHistory(JSON.parse(saved))
-
-      // 2. Si el usuario está autenticado, sincronizar con el servidor
+    const syncHistory = async () => {
       const token = localStorage.getItem("token")
-      if (token) {
-        try {
-          const res = await fetch(`${API_BASE}/api/perfil/historial-busqueda`, {
-            headers: { 
-              'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            }
-          })
-          if (res.ok) {
-            const data = await res.json()
-            // Asumiendo que el backend devuelve un array de strings o de objetos {termino: string}
-            const remoteHistory = data.map((h: any) => typeof h === 'string' ? h : h.termino)
-            
-            // SINCRONIZACIÓN: Guardar en el backend las búsquedas locales que no estén en el remoto
-            const localHistory = saved ? JSON.parse(saved) : [];
-            const missingInRemote = localHistory.filter((item: string) => !remoteHistory.includes(item));
-            
-            if (missingInRemote.length > 0) {
-              // Enviamos al backend desde la más antigua a la más nueva para mantener el orden
-              for (const item of [...missingInRemote].reverse()) {
-                try {
-                  await fetch(`${API_BASE}/api/perfil/historial-busqueda`, {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                      Authorization: `Bearer ${token}`
-                    },
-                    body: JSON.stringify({ termino: item })
-                  });
-                } catch (e) {
-                  console.error("Error sincronizando historial local:", e);
-                }
-              }
-              // Unimos la historia local que no estaba y la remota, y guardamos hasta 20 items
-              const newHistory = [...missingInRemote, ...remoteHistory].slice(0, 20);
-              setHistory(newHistory);
-              localStorage.setItem('searchHistory', JSON.stringify(newHistory));
-            } else {
-              setHistory(remoteHistory)
-              localStorage.setItem('searchHistory', JSON.stringify(remoteHistory))
-            }
-          } else if (res.status === 401) {
-            console.warn("Sesión expirada o token inválido para historial")
-            setIsAuth(false)
+
+      // Si no hay token (visitor o cierre de sesión), limpiar historial
+      if (!token) {
+        setHistory([])
+        localStorage.removeItem('searchHistory')
+        setIsAuth(false)
+        return
+      }
+
+      try {
+        const res = await fetch(`${API_BASE}/api/perfil/historial-busqueda`, {
+          headers: { 
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
           }
-        } catch (error) {
-          console.error("Error cargando historial remoto:", error)
+        })
+        if (res.ok) {
+          const data = await res.json()
+          const remoteHistory = data
+            .map((h: any) => typeof h === 'string' ? h : h.termino)
+            .filter((item: string, index: number, self: string[]) => self.indexOf(item) === index)
+          
+          setHistory(remoteHistory)
+          localStorage.setItem('searchHistory', JSON.stringify(remoteHistory))
+          setIsAuth(true)
+        } else if (res.status === 401 || res.status === 403) {
+          // Token inválido: limpiar todo
+          setHistory([])
+          localStorage.removeItem('searchHistory')
+          setIsAuth(false)
         }
+      } catch (error) {
+        console.error("Error cargando historial remoto:", error)
       }
     }
-    initHistory()
-  }, [isAuth]) // Depende de isAuth para recargar cuando el usuario inicia sesión
+
+    // Ejecutar al montar y cada vez que cambie la sesión
+    syncHistory()
+
+    const handleSessionChange = () => void syncHistory()
+    window.addEventListener('propbol:session-changed', handleSessionChange)
+    window.addEventListener('propbol:login', handleSessionChange)
+
+    return () => {
+      window.removeEventListener('propbol:session-changed', handleSessionChange)
+      window.removeEventListener('propbol:login', handleSessionChange)
+    }
+  }, []) // Solo se monta una vez; los eventos manejan re-sincronización
 
   // --- PERSISTENCIA: Guardar ---
   const saveToHistory = async (item: string) => {
@@ -229,24 +220,7 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
     return () => clearTimeout(timer)
   }, [value, isSelected])
 
-  useEffect(() => {
-    const checkAuth = async () => {
-      const token = localStorage.getItem("token")
-      if (!token) {
-        setIsAuth(false)
-        return
-      }
-      try {
-        const res = await fetch(`${API_BASE}/api/auth/me`, {
-          headers: { Authorization: `Bearer ${token}` }
-        })
-        setIsAuth(res.ok)
-      } catch (error) {
-        setIsAuth(false)
-      }
-    }
-    checkAuth()
-  }, [])
+  // isAuth se gestiona directamente en syncHistory arriba
 
   return (
     <div className="w-full relative" ref={containerRef}>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -108,6 +108,7 @@ export default function Navbar() {
       localStorage.removeItem("nombre");
       localStorage.removeItem("correo");
       localStorage.removeItem("avatar");
+      localStorage.removeItem("searchHistory");
       setUser(null);
       setIsPanelOpen(false);
       setShowLogoutModal(false);

--- a/frontend/src/components/layout/auth/formularioSignIn.tsx
+++ b/frontend/src/components/layout/auth/formularioSignIn.tsx
@@ -124,6 +124,7 @@ const clearClientSession = () => {
   localStorage.removeItem("nombre");
   localStorage.removeItem("correo");
   localStorage.removeItem("avatar");
+  localStorage.removeItem("searchHistory");
 
   window.dispatchEvent(new Event("propbol:session-changed"));
   window.dispatchEvent(new Event("auth-state-changed"));


### PR DESCRIPTION
Backend
- Se actualizó el controlador `getHistorialBusqueda` para filtrar duplicados antes de devolver el historial al cliente, garantizando que solo se retornen términos únicos aunque existan registros repetidos en la base de datos.
Frontend
- Se unificó la lógica de carga y sincronización del historial en una sola función `syncHistory`, eliminando la separación anterior entre `initHistory` y `checkAuth`.
- El componente ahora escucha los eventos globales 
  `propbol:session-changed` y `propbol:login` para reaccionar en tiempo real a cambios de sesión.
- Al cerrar sesión, el historial se limpia inmediatamente del estado 
  en memoria y del localStorage, evitando que el historial de un usuario autenticado sea visible en modo visitante.
- Se añadió filtrado de duplicados en el cliente como capa adicional de seguridad.
- El historial se limpia instantáneamente al cerrar sesión.
- Solo se muestran términos únicos sin importar cuántos  dispositivos usen la misma cuenta.