### PR TITLE
Feature/publicacion hu3 cloudinary multimedia

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^7.6.0",
     "@supabase/supabase-js": "^2.101.0",
     "@vercel/node": "^5.6.22",
+    "cloudinary": "^2.10.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",

--- a/backend/src/config/cloudinary.ts
+++ b/backend/src/config/cloudinary.ts
@@ -1,0 +1,11 @@
+import { v2 as cloudinary } from "cloudinary";
+import { env } from "./env.js";
+
+cloudinary.config({
+  cloud_name: env.CLOUDINARY_CLOUD_NAME,
+  api_key: env.CLOUDINARY_API_KEY,
+  api_secret: env.CLOUDINARY_API_SECRET,
+  secure: true,
+});
+
+export { cloudinary };

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -41,4 +41,11 @@ export const env = {
   EVOLUTION_API_URL: process.env.EVOLUTION_API_URL ?? "http://localhost:8080",
   EVOLUTION_API_KEY: process.env.EVOLUTION_API_KEY ?? "",
   EVOLUTION_INSTANCE: process.env.EVOLUTION_INSTANCE ?? "propbol",
+
+  CLOUDINARY_CLOUD_NAME: requireEnv("CLOUDINARY_CLOUD_NAME"),
+  CLOUDINARY_API_KEY: requireEnv("CLOUDINARY_API_KEY"),
+  CLOUDINARY_API_SECRET: requireEnv("CLOUDINARY_API_SECRET"),
+  CLOUDINARY_MULTIMEDIA_FOLDER:
+    process.env.CLOUDINARY_MULTIMEDIA_FOLDER ??
+    "propbol/publicaciones/multimedia",
 };

--- a/backend/src/modules/multimedia/cloudinary.service.ts
+++ b/backend/src/modules/multimedia/cloudinary.service.ts
@@ -1,0 +1,46 @@
+import type { UploadApiResponse } from 'cloudinary'
+import { Readable } from 'stream'
+import { cloudinary } from '../../config/cloudinary.js'
+import { env } from '../../config/env.js'
+
+type CloudinaryUploadImageResult = {
+  url: string
+  pesoMb: number
+  publicId: string
+}
+
+const getCloudinaryFolder = (publicacionId: number) => {
+  return `${env.CLOUDINARY_MULTIMEDIA_FOLDER}/${publicacionId}`
+}
+
+export const uploadImageToCloudinary = async (
+  file: Express.Multer.File,
+  publicacionId: number
+): Promise<CloudinaryUploadImageResult> => {
+  return new Promise((resolve, reject) => {
+    const uploadStream = cloudinary.uploader.upload_stream(
+      {
+        folder: getCloudinaryFolder(publicacionId),
+        resource_type: 'image',
+        use_filename: true,
+        unique_filename: true,
+        overwrite: false
+      },
+      (error, result?: UploadApiResponse) => {
+        if (error || !result) {
+          reject(error ?? new Error('No se pudo subir la imagen a Cloudinary'))
+          return
+        }
+
+        resolve({
+          url: result.secure_url,
+          publicId: result.public_id,
+          pesoMb: Number((file.size / (1024 * 1024)).toFixed(2))
+        })
+      }
+    )
+
+    Readable.from(file.buffer).pipe(uploadStream)
+  })
+}
+

--- a/backend/src/modules/multimedia/multimedia.controller.ts
+++ b/backend/src/modules/multimedia/multimedia.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express'
 import type { Express } from 'express'
-import path from 'path'
+import { uploadImageToCloudinary } from './cloudinary.service.js'
 import {
   getPublicationMultimediaService,
   registerImagesService,
@@ -68,14 +68,13 @@ const getErrorStatus = (message: string): number => {
 
 const handleControllerError = (error: unknown, res: Response) => {
   const message = error instanceof Error ? error.message : 'Error interno del servidor'
-
   const status = getErrorStatus(message)
 
   if (status === 500) {
     console.error('[multimedia.controller] Error inesperado:', error)
   }
 
-  res.status(status).json({
+  return res.status(status).json({
     message: status === 500 ? 'Error interno del servidor' : message
   })
 }
@@ -90,12 +89,12 @@ export const getPublicationMultimediaController = async (req: Request, res: Resp
       usuarioId
     })
 
-    res.json({
+    return res.json({
       message: 'Multimedia obtenida correctamente',
       data: result
     })
   } catch (error) {
-    handleControllerError(error, res)
+    return handleControllerError(error, res)
   }
 }
 
@@ -111,12 +110,12 @@ export const registerVideoLinkController = async (req: Request, res: Response) =
       videoUrl: typeof videoUrl === 'string' ? videoUrl : ''
     })
 
-    res.status(201).json({
+    return res.status(201).json({
       message: 'Video registrado correctamente',
       data: result
     })
   } catch (error) {
-    handleControllerError(error, res)
+    return handleControllerError(error, res)
   }
 }
 
@@ -124,19 +123,24 @@ export const registerImagesController = async (req: Request, res: Response) => {
   try {
     const publicacionId = parsePublicacionId(req)
     const usuarioId = getAuthenticatedUserId(req as AuthenticatedRequest)
-
     const files = (req as AuthenticatedRequest).files ?? []
 
-    const normalizedImages: ImageUploadItemInput[] = files.map((file) => {
-      const extension = path.extname(file.originalname).replace('.', '').toLowerCase()
-      const pesoMb = Number((file.size / (1024 * 1024)).toFixed(2))
+    if (files.length === 0) {
+      throw new Error('Debe enviar al menos una imagen')
+    }
 
-      return {
-        url: `/uploads/${file.filename}`,
-        extension,
-        pesoMb
-      }
-    })
+    const normalizedImages: ImageUploadItemInput[] = await Promise.all(
+      files.map(async (file) => {
+        const extension = file.originalname.split('.').pop()?.toLowerCase() ?? ''
+        const uploadedImage = await uploadImageToCloudinary(file, publicacionId)
+
+        return {
+          url: uploadedImage.url,
+          extension,
+          pesoMb: uploadedImage.pesoMb
+        }
+      })
+    )
 
     const result = await registerImagesService({
       publicacionId,
@@ -144,11 +148,11 @@ export const registerImagesController = async (req: Request, res: Response) => {
       images: normalizedImages
     })
 
-    res.status(201).json({
+    return res.status(201).json({
       message: 'Imágenes registradas correctamente',
       data: result
     })
   } catch (error) {
-    handleControllerError(error, res)
+    return handleControllerError(error, res)
   }
 }

--- a/backend/src/modules/multimedia/multimedia.routes.ts
+++ b/backend/src/modules/multimedia/multimedia.routes.ts
@@ -10,7 +10,20 @@ import {
 const multimediaRoutes = Router()
 
 const upload = multer({
-  dest: 'uploads/'
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024
+  },
+  fileFilter: (_req, file, cb) => {
+    const allowedMimeTypes = ['image/png', 'image/jpeg', 'image/jpg']
+
+    if (!allowedMimeTypes.includes(file.mimetype)) {
+      cb(new Error('Formato no permitido. Solo PNG, JPG o JPEG'))
+      return
+    }
+
+    cb(null, true)
+  }
 })
 
 multimediaRoutes.get('/:publicacionId/multimedia', requireAuth, getPublicationMultimediaController)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vercel/node':
         specifier: ^5.6.22
         version: 5.7.2
+      cloudinary:
+        specifier: ^2.10.0
+        version: 2.10.0
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -1977,6 +1980,10 @@ packages:
   clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
+
+  cloudinary@2.10.0:
+    resolution: {integrity: sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==}
+    engines: {node: '>=9'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -6505,6 +6512,10 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@2.1.2: {}
+
+  cloudinary@2.10.0:
+    dependencies:
+      lodash: 4.18.1
 
   clsx@2.1.1: {}
 


### PR DESCRIPTION
## Resumen

Se integra Cloudinary al flujo de carga multimedia de publicaciones, reemplazando el almacenamiento local en `/uploads` por almacenamiento externo seguro en Cloudinary.

## Cambios realizados

- Se agregó la dependencia `cloudinary` al backend.
- Se agregaron variables Cloudinary al archivo centralizado `backend/src/config/env.ts`.
- Se creó la configuración del SDK en `backend/src/config/cloudinary.ts`.
- Se creó el servicio `cloudinary.service.ts` para subir imágenes mediante `upload_stream`.
- Se cambió `multer` de almacenamiento local a `memoryStorage`.
- Se actualizó el controller de multimedia para guardar `secure_url` en la tabla `multimedia`.
- Se mantiene la lógica existente para videos por enlaces de YouTube.
- Se conserva compatibilidad con registros antiguos que usen `/uploads/...`.

## Validaciones realizadas

- `pnpm --filter backend tsc --noEmit`
- `git diff --check`
- Backend levantado en `localhost:5000`
- Prueba en Postman:
  - `POST /api/publicaciones/67/multimedia/images`
  - Respuesta `201 Created`
  - URL generada correctamente desde Cloudinary
- Verificación en Prisma Studio:
  - Tabla `multimedia`
  - Campo `url` con `https://res.cloudinary.com/...`
- Verificación en Cloudinary Assets:
  - Carpeta `propbol/publicaciones/multimedia/67`
- GitHub Actions:
  - Lint OK
  - TypeScript Check OK
  - Build Backend OK
  - Build Frontend OK

## Notas

Las credenciales de Cloudinary se configuran únicamente en `backend/.env` y no se suben al repositorio.

El frontend no contiene claves de Cloudinary. La subida se realiza desde backend para mantener segura la clave `CLOUDINARY_API_SECRET`.

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/0b54c1a6-859d-40fd-834e-b76c1c1e8f93" />

<img width="1600" height="845" alt="image" src="https://github.com/user-attachments/assets/cb95f2a4-0261-406b-831c-fc3b1d55585d" />

<img width="1600" height="845" alt="image" src="https://github.com/user-attachments/assets/9a7324e1-5846-444c-9965-f1345c9ce52a" />

<img width="928" height="1055" alt="image" src="https://github.com/user-attachments/assets/f916267e-5dc4-43f9-b493-4d2e43824c2e" />


