### PR TITLE
Fix/blogs recientes

### DIFF
--- a/frontend/src/app/blog/[id]/page.tsx
+++ b/frontend/src/app/blog/[id]/page.tsx
@@ -66,6 +66,7 @@ export default async function BlogDetailPage({ params }: { params: { id: string 
             width={1600}
             height={900}
             className="h-full min-h-[240px] w-full object-cover sm:min-h-[360px]"
+            unoptimized
           />
         </div>
       </header>

--- a/frontend/src/app/blogs/page.tsx
+++ b/frontend/src/app/blogs/page.tsx
@@ -43,8 +43,8 @@ export default function BlogsPage() {
             Perspectivas para el Bien Raiz Moderno.
           </h1>
 
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="overflow-x-auto pb-1">
+          <div className="flex flex-row items-center justify-between gap-4">
+            <div className="flex-1 overflow-x-auto pb-1">
               <BlogFilterChips
                 categories={categories}
                 activeCategory={activeCategory}
@@ -52,9 +52,8 @@ export default function BlogsPage() {
               />
             </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <div className="flex-shrink-0">
               <AddPostButton />
-
             </div>
           </div>
         </section>

--- a/frontend/src/app/blogs/page.tsx
+++ b/frontend/src/app/blogs/page.tsx
@@ -28,54 +28,15 @@ export default function BlogsPage() {
     secondaryBlogs,
     canLoadMore,
     hasResults,
+    isLoading,
     toggleCategory,
     loadMore,
   } = useBlogFeed();
 
-  const [myBlogs, setMyBlogs] = useState<Blog[]>([]);
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-
-    if (!token) return;
-
-    const loadMyBlogs = async () => {
-      try {
-        const res = await fetch(`${API_URL}/api/blogs/mis-blogs`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-
-        if (!res.ok) {
-          throw new Error("No se pudieron cargar tus blogs");
-        }
-
-        const data = (await res.json()) as UserBlogResponse[];
-
-        setMyBlogs(
-          data.map((blog) => ({
-            id: blog.id,
-            titulo: blog.titulo,
-            estado: blog.estado,
-            fecha: blog.fecha_creacion
-              ? new Date(blog.fecha_creacion).toLocaleDateString("es-BO")
-              : "",
-            imagenUrl: blog.imagen || "/placeholder-house.jpg",
-          })),
-        );
-      } catch (loadError) {
-        console.error(loadError);
-      }
-    };
-
-    void loadMyBlogs();
-  }, []);
-
   return (
     <div className="min-h-screen bg-[linear-gradient(180deg,#fbf6ef_0%,#f5efe7_45%,#ffffff_100%)]">
       <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-        <MyRecentBlogsPanel blogs={myBlogs} />
+        <MyRecentBlogsPanel />
 
         <section className="space-y-6">
           <h1 className="max-w-3xl font-heading text-4xl font-bold leading-tight text-stone-900 sm:text-5xl">
@@ -98,7 +59,16 @@ export default function BlogsPage() {
           </div>
         </section>
 
-        {hasResults && featuredBlog ? (
+        {isLoading ? (
+          <section className="rounded-[32px] border border-stone-200 bg-white px-6 py-12 text-center shadow-sm">
+            <div className="animate-pulse flex flex-col items-center">
+              <div className="h-4 bg-stone-200 rounded w-1/4 mb-4"></div>
+              <div className="h-8 bg-stone-200 rounded w-1/2 mb-4"></div>
+              <div className="h-4 bg-stone-200 rounded w-3/4"></div>
+            </div>
+            <p className="mt-4 text-sm text-stone-400">Cargando artículos...</p>
+          </section>
+        ) : hasResults && featuredBlog ? (
           <FeaturedBlogSpotlight blog={featuredBlog} />
         ) : (
           <section className="rounded-[32px] border border-dashed border-stone-300 bg-white px-6 py-12 text-center shadow-sm">
@@ -117,31 +87,33 @@ export default function BlogsPage() {
           </section>
         )}
 
-        <section className="space-y-6">
-          {secondaryBlogs.length > 0 ? (
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-              {secondaryBlogs.map((blog) => (
-                <BlogCard key={blog.id} {...blog} />
-              ))}
-            </div>
-          ) : hasResults ? (
-            <div className="rounded-[28px] border border-stone-200 bg-white px-6 py-10 text-center text-stone-600 shadow-sm">
-              Esta categoria solo tiene un articulo destacado por el momento.
-            </div>
-          ) : null}
+        {!isLoading && (
+          <section className="space-y-6">
+            {secondaryBlogs.length > 0 ? (
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+                {secondaryBlogs.map((blog) => (
+                  <BlogCard key={blog.id} {...blog} />
+                ))}
+              </div>
+            ) : hasResults ? (
+              <div className="rounded-[28px] border border-stone-200 bg-white px-6 py-10 text-center text-stone-600 shadow-sm">
+                Esta categoria solo tiene un articulo destacado por el momento.
+              </div>
+            ) : null}
 
-          {canLoadMore && (
-            <div className="flex justify-center pt-2">
-              <button
-                type="button"
-                onClick={loadMore}
-                className="rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-700 transition-colors hover:bg-amber-600 hover:text-white"
-              >
-                CONTINUAR LEYENDO
-              </button>
-            </div>
-          )}
-        </section>
+            {canLoadMore && (
+              <div className="flex justify-center pt-2">
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  className="rounded-full border border-amber-600 px-6 py-3 text-sm font-semibold text-amber-700 transition-colors hover:bg-amber-600 hover:text-white"
+                >
+                  CONTINUAR LEYENDO
+                </button>
+              </div>
+            )}
+          </section>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/mis-blogs/page.tsx
+++ b/frontend/src/app/mis-blogs/page.tsx
@@ -186,8 +186,17 @@ export default function MisBlogsPage() {
             {filtrados.map((blog) => (
               <div
                 key={blog.id}
+                tabIndex={0}
+                role="button"
+                aria-label={`Ver detalle del blog: ${blog.titulo}`}
                 onClick={() => router.push(`/blog/${blog.id}`)}
-                className="cursor-pointer bg-white border border-[#E8DED0] rounded-[22px] overflow-hidden shadow-sm hover:shadow-xl hover:-translate-y-1 transition"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    router.push(`/blog/${blog.id}`);
+                  }
+                }}
+                className="cursor-pointer bg-white border border-[#E8DED0] rounded-[22px] overflow-hidden shadow-sm hover:shadow-xl hover:-translate-y-1 transition focus:outline-none focus:ring-2 focus:ring-[#C28700] focus:ring-offset-2"
               >
                 <div className="relative h-52 bg-[#E5E0DA]">
                   <img
@@ -234,7 +243,7 @@ export default function MisBlogsPage() {
                           e.stopPropagation();
                           router.push(`/blog/${blog.id}/edit`);
                         }}
-                        className="text-xs font-bold text-[#3F3F3F] hover:text-[#B47A00] transition"
+                        className="text-xs font-bold text-[#3F3F3F] hover:text-[#B47A00] transition rounded focus:outline-none focus:ring-2 focus:ring-[#B47A00] focus:ring-offset-4"
                       >
                         ✎ {blog.estado === "BORRADOR" ? "Continuar" : "Editar"}
                       </button>
@@ -247,7 +256,7 @@ export default function MisBlogsPage() {
                         e.stopPropagation();
                         eliminarBlog(blog.id);
                       }}
-                      className="text-xs font-bold text-red-400 hover:text-red-600 transition"
+                      className="text-xs font-bold text-red-400 hover:text-red-600 transition rounded focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-4"
                     >
                       🗑 Eliminar
                     </button>

--- a/frontend/src/app/mis-blogs/page.tsx
+++ b/frontend/src/app/mis-blogs/page.tsx
@@ -137,7 +137,7 @@ export default function MisBlogsPage() {
             <ResumenCard
               titulo="Pendientes"
               valor={count("PENDIENTE")}
-              color="text-blue-600"
+              color="text-amber-600"
             />
 
             <ResumenCard
@@ -154,11 +154,12 @@ export default function MisBlogsPage() {
             <button
               key={estado}
               onClick={() => setFiltro(estado)}
-              className={`px-5 py-2 rounded-full text-xs font-extrabold uppercase tracking-[0.16em] border transition ${
-                filtro === estado
+              className={`flex items-center px-5 py-2 rounded-full text-xs font-extrabold uppercase tracking-[0.16em] border transition ${filtro === estado
                   ? "bg-[#111111] text-white border-[#111111]"
-                  : "bg-white text-[#242424] border-[#D8CEC2] hover:bg-[#FAF7F2]"
-              }`}
+                  : estado === "TODOS"
+                    ? "bg-white text-[#242424] border-[#D8CEC2] hover:bg-[#FAF7F2]"
+                    : `${getEstadoColor(estado)} hover:opacity-80`
+                }`}
             >
               {estado === "TODOS" ? "Todos" : getEstadoLabel(estado)}
 
@@ -225,9 +226,9 @@ export default function MisBlogsPage() {
 
                   <div className="flex justify-between items-center border-t border-[#EEE6DC] pt-4">
                     {blog.estado === "BORRADOR" ||
-                    blog.estado === "RECHAZADO" ||
-                    blog.estado === "PENDIENTE" ||
-                    blog.estado === "PUBLICADO" ? (
+                      blog.estado === "RECHAZADO" ||
+                      blog.estado === "PENDIENTE" ||
+                      blog.estado === "PUBLICADO" ? (
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -303,7 +304,7 @@ function getEstadoColor(estado: string) {
     case "PUBLICADO":
       return "bg-[#E8F7EE] text-[#198754] border-[#BFE8CD]";
     case "PENDIENTE":
-      return "bg-[#EAF2FF] text-[#2563EB] border-[#C7DDFE]";
+      return "bg-amber-50 text-amber-700 border-amber-200";
     case "RECHAZADO":
       return "bg-[#FDECEC] text-[#D94848] border-[#F3BABA]";
     case "BORRADOR":

--- a/frontend/src/components/blog/FeaturedBlogSpotlight.tsx
+++ b/frontend/src/components/blog/FeaturedBlogSpotlight.tsx
@@ -19,6 +19,7 @@ export default function FeaturedBlogSpotlight({
             width={1200}
             height={900}
             className="h-full min-h-[260px] w-full object-cover transition-transform duration-500 group-hover:scale-[1.03] sm:min-h-[320px]"
+            unoptimized
           />
         </div>
 

--- a/frontend/src/components/blog/MyRecentBlogsPanel.tsx
+++ b/frontend/src/components/blog/MyRecentBlogsPanel.tsx
@@ -161,6 +161,7 @@ const MyRecentBlogsPanel: React.FC<MyRecentBlogsPanelProps> = ({ blogs: propBlog
                 fill
                 className="object-cover"
                 sizes="80px"
+                unoptimized
               />
             </div>
 

--- a/frontend/src/components/blog/MyRecentBlogsPanel.tsx
+++ b/frontend/src/components/blog/MyRecentBlogsPanel.tsx
@@ -50,6 +50,7 @@ type UserBlogResponse = {
 const MyRecentBlogsPanel: React.FC<MyRecentBlogsPanelProps> = ({ blogs: propBlogs }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [internalBlogs, setInternalBlogs] = useState<Blog[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const syncAuthState = async () => {
@@ -58,6 +59,7 @@ const MyRecentBlogsPanel: React.FC<MyRecentBlogsPanelProps> = ({ blogs: propBlog
       setIsAuthenticated(isAuth);
 
       if (token) {
+        setIsLoading(true);
         try {
           const res = await fetch(`${API_URL}/api/blogs/mis-blogs`, {
             headers: { Authorization: `Bearer ${token}` }
@@ -76,7 +78,12 @@ const MyRecentBlogsPanel: React.FC<MyRecentBlogsPanelProps> = ({ blogs: propBlog
               : ''
           }));
           setInternalBlogs(mapped);
-        } catch { }
+        } catch {
+        } finally {
+          setIsLoading(false);
+        }
+      } else {
+        setIsLoading(false);
       }
     };
 
@@ -95,10 +102,24 @@ const MyRecentBlogsPanel: React.FC<MyRecentBlogsPanelProps> = ({ blogs: propBlog
   const blogs = propBlogs || internalBlogs;
   const visible = blogs.slice(0, MAX_VISIBLE);
 
+  if (isLoading && !propBlogs) {
+    return (
+      <section className="bg-white rounded-[32px] p-6 border border-stone-100 shadow-sm mb-10">
+        <div className="animate-pulse flex space-x-4">
+          <div className="flex-1 space-y-4 py-1">
+            <div className="h-4 bg-stone-200 rounded w-1/4"></div>
+            <div className="h-4 bg-stone-200 rounded w-1/2"></div>
+          </div>
+        </div>
+        <p className="mt-4 text-sm text-stone-400">Cargando tus blogs...</p>
+      </section>
+    );
+  }
+
   if (blogs.length === 0) {
     return (
       <section className="bg-white rounded-[32px] p-6 border border-stone-100 shadow-sm mb-10">
-        <p className="text-sm text-gray-400">No publicaste ningún blog aún</p>
+        <p className="text-sm text-stone-400">No publicaste ningún blog aún</p>
       </section>
     );
   }

--- a/frontend/src/components/blog/UserBlogCard.tsx
+++ b/frontend/src/components/blog/UserBlogCard.tsx
@@ -20,6 +20,7 @@ const UserBlogCard: React.FC<UserBlogCardProps> = ({ blog }) => {
           alt={blog.titulo}
           fill
           className="object-cover"
+          unoptimized
         />
       </div>
 

--- a/frontend/src/components/blog/admin/AdminBlogReview.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogReview.tsx
@@ -167,6 +167,7 @@ export default function AdminBlogReview({ blogId }: { blogId: string }) {
               height={980}
               className="h-auto w-full object-cover"
               priority
+              unoptimized
             />
           </div>
 

--- a/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
@@ -67,6 +67,7 @@ function BlogRow({ blog }: { blog: AdminModerationBlog }) {
             width={56}
             height={56}
             className="h-14 w-14 object-cover"
+            unoptimized
           />
         </div>
 

--- a/frontend/src/components/blog/form/BlogImageSection.tsx
+++ b/frontend/src/components/blog/form/BlogImageSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Camera } from "lucide-react";
+import { useState } from "react";
 
 interface BlogImageSectionProps {
   imagePreviewUrl: string;
@@ -8,25 +9,86 @@ interface BlogImageSectionProps {
   error?: string;
 }
 
+const compressToWebp = (file: File): Promise<File> => {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      const MAX_WIDTH = 1920;
+      const MAX_HEIGHT = 1080;
+      let width = img.width;
+      let height = img.height;
+
+      if (width > MAX_WIDTH || height > MAX_HEIGHT) {
+        const ratio = Math.min(MAX_WIDTH / width, MAX_HEIGHT / height);
+        width = Math.round(width * ratio);
+        height = Math.round(height * ratio);
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        resolve(file);
+        return;
+      }
+      ctx.drawImage(img, 0, 0, width, height);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const newFile = new File([blob], file.name.replace(/\.[^/.]+$/, "") + ".webp", {
+              type: "image/webp",
+              lastModified: Date.now(),
+            });
+            resolve(newFile);
+          } else {
+            resolve(file);
+          }
+        },
+        "image/webp",
+        0.8
+      );
+    };
+    img.onerror = () => resolve(file);
+  });
+};
+
 export default function BlogImageSection({ 
   imagePreviewUrl, 
   onImageChange, 
   error 
 }: BlogImageSectionProps) {
+  const [isCompressing, setIsCompressing] = useState(false);
+
   return (
     <div className="space-y-2">
-      <label className="relative flex min-h-[300px] cursor-pointer flex-col items-center justify-center rounded-[32px] border-2 border-dashed border-[#E7E5E4] bg-[#FAFAFA] px-10 py-12 text-center transition hover:border-[#F59E0B] hover:bg-white group">
+      <label className={`relative flex min-h-[300px] cursor-pointer flex-col items-center justify-center rounded-[32px] border-2 border-dashed border-[#E7E5E4] bg-[#FAFAFA] px-10 py-12 text-center transition hover:border-[#F59E0B] hover:bg-white group ${isCompressing ? "opacity-50 pointer-events-none" : ""}`}>
         <input
           type="file"
           accept="image/png,image/jpeg,image/webp"
           className="sr-only"
-          onChange={(event) => {
+          onChange={async (event) => {
             const file = event.target.files?.[0] ?? null;
-            onImageChange(file);
+            if (file) {
+              setIsCompressing(true);
+              const compressedFile = await compressToWebp(file);
+              setIsCompressing(false);
+              onImageChange(compressedFile);
+            } else {
+              onImageChange(null);
+            }
           }}
         />
 
-        {imagePreviewUrl ? (
+        {isCompressing ? (
+          <div className="flex flex-col items-center justify-center">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#F59E0B] border-t-transparent mb-4"></div>
+            <p className="text-sm font-semibold text-[#1C1917]">Comprimiendo imagen...</p>
+          </div>
+        ) : imagePreviewUrl ? (
           <div className="absolute inset-0 overflow-hidden rounded-[32px]">
             <img
               src={imagePreviewUrl}
@@ -46,7 +108,7 @@ export default function BlogImageSection({
               Arrastra y suelta la imagen destacada
             </p>
             <p className="mt-1 text-xs font-medium text-[#78716C]">
-              Recomendado: 1920×820px (JPG, PNG)
+              Recomendado: 1920×820px (Se comprimirá automáticamente a WebP)
             </p>
           </>
         )}

--- a/frontend/src/components/home/HomeBlogsSection.tsx
+++ b/frontend/src/components/home/HomeBlogsSection.tsx
@@ -50,12 +50,12 @@ export default async function HomeBlogsSection() {
                 Blogs
               </p>
               <h3 className="font-['Montserrat'] text-6xl font-black uppercase tracking-tighter text-stone-900 sm:text-7xl">
-                Aprende
+                Descubre
               </h3>
             </div>
 
             <p className="font-['Inter'] text-lg leading-relaxed text-stone-600 max-w-sm">
-              Exploramos la intersección entre la arquitectura de vanguardia, el mercado de capitales y el estilo de vida contemporáneo.
+              Mantente al día con las últimas tendencias del mercado, consejos de inversión y guías prácticas para encontrar la propiedad de tus sueños.
             </p>
 
             <Link


### PR DESCRIPTION
🖼️ Optimización de Imágenes
Bypass de Vercel Limits: Se añadió la propiedad unoptimized a todos los componentes <Image /> de next/image en las vistas de blogs (tarjetas, panel de admin, spotlights, vista de detalles). Esto previene que Vercel consuma el límite de cuota gratuita de optimización de imágenes.
Compresión del lado del cliente (WebP): Se implementó la función compressToWebp en el formulario de creación de blogs (BlogImageSection.tsx).
Redimensiona automáticamente imágenes grandes a un máximo de 1920x1080 píxeles.
Convierte las imágenes a formato ligero .webp (calidad 80%) antes de enviarlas al servidor.
Se añadió un indicador visual de "Comprimiendo imagen..." que deshabilita temporalmente el input durante el proceso.
🎨 Consistencia Visual (UI)
Estandarización de colores de estado: En el panel /mis-blogs, se estandarizaron los colores para coincidir con la convención global:
🟢 Aprobado/Publicado: Verde
🟡 Pendiente: Ámbar / Amarillo (anteriormente era azul)
🔴 Rechazado: Rojo
⚪ Borrador: Gris
Pestañas (Tabs) de Filtrado Dinámicas: Las pestañas de filtrado ahora reflejan visualmente el color de su estado respectivo (ej. verde claro para aprobados, ámbar para pendientes) en lugar de ser todas blancas, mejorando la lectura rápida.
♿ Accesibilidad y Navegabilidad (a11y)
Navegación por Teclado: Se refactorizó la tarjeta de cada blog en /mis-blogs para que pueda ser navegada 100% mediante el tabulador (tabIndex={0}, role="button").
Soporte de Enter/Espacio: Ahora es posible ingresar a un blog presionado la tecla Enter o Espacio mientras el foco está sobre su tarjeta (onKeyDown).
Focus Rings (Anillos de foco visuales): Se añadieron estilos de focus explícitos (contornos naranjas y ámbar) a las tarjetas y a los botones interiores ("Editar", "Eliminar") para dar feedback visual claro al navegar con teclado.
Screen Readers: Se incluyó la etiqueta aria-label en las tarjetas para lectores de pantalla.