### PR TITLE
fix: configuración de dominio permitido para imágenes de Cloudinary

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -38,6 +38,12 @@ const nextConfig = {
         pathname: '/**'
       },
       {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        port: '',
+        pathname: '/**', // Permite cualquier ruta dentro de Cloudinary
+      },
+      {
         protocol: 'http',
         hostname: '127.0.0.1',
         port: '5000',


### PR DESCRIPTION
##Cambios Realizados
- **Frontend:**
  - Modificación de `frontend/next.config.mjs` para añadir `res.cloudinary.com` a la lista de `remotePatterns`.
  - Configuración del protocolo HTTPS para permitir la carga segura de multimedia desde el Hub de PropBol.