### PR TITLE
Hotfix/filtros visuales homepage

### DIFF
--- a/frontend/src/components/VisualFilters/PropertyCard.tsx
+++ b/frontend/src/components/VisualFilters/PropertyCard.tsx
@@ -56,7 +56,7 @@ export default function PropertyCard({
   }, [slides.length]);
 
   const currentSlide = slides[currentIndex];
-  const showImage = !!currentSlide.imagen;
+  const showImage = Boolean(currentSlide?.imagen);
 
 
   return (

--- a/frontend/src/components/VisualFilters/PropertyCard.tsx
+++ b/frontend/src/components/VisualFilters/PropertyCard.tsx
@@ -61,20 +61,20 @@ export default function PropertyCard({
 
   return (
     <div
-      onClick={onClick}
+      onClick={isEmpty ? undefined : onClick}
       className={`
-        relative cursor-pointer rounded-xl overflow-hidden bg-white
-        shadow-sm border border-gray-100
-        transition-all duration-200 hover:scale-105 hover:shadow-lg
-        ${isAlquiler ? "min-w-[200px] w-[200px]" : "min-w-[160px] w-[160px]"}
+        group relative flex flex-col rounded-[20px] overflow-hidden bg-white
+        shadow-[0_2px_10px_rgba(0,0,0,0.04)] border border-gray-100 p-3
+        transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_8px_20px_rgba(0,0,0,0.08)]
+        ${isAlquiler ? "min-w-[220px] w-[220px]" : "min-w-[240px] w-[240px]"}
         flex-shrink-0
       `}
     >
       {/* Imagen */}
       <div
         className={`
-          relative w-full overflow-hidden bg-gray-100
-          ${isAlquiler ? "h-[140px]" : "h-[100px]"}
+          relative w-full overflow-hidden bg-gray-100 rounded-2xl
+          ${isAlquiler ? "h-[140px]" : "h-[160px]"}
         `}
       >
         {isEmpty || !showImage ? (
@@ -110,15 +110,6 @@ export default function PropertyCard({
               className="w-full h-full object-cover transition-opacity duration-500"
             />
 
-            {/* Título del inmueble rotando */}
-            {previews.length > 0 && (
-              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent px-2 py-1">
-                <p className="text-white text-[9px] font-medium truncate">
-                  {currentSlide.titulo}
-                </p>
-              </div>
-            )}
-
             {/* Indicadores de slide */}
             {slides.length > 1 && (
               <div className="absolute top-1 left-1/2 -translate-x-1/2 flex gap-0.5">
@@ -134,7 +125,7 @@ export default function PropertyCard({
           </>
         )}
 
-        {/* ALQUILERES */}
+        {/* ALQUILERES: badge superior derecho */}
         {isAlquiler && count !== undefined && (
           <span
             className={`
@@ -149,28 +140,28 @@ export default function PropertyCard({
       </div>
 
       {/* Info */}
-      <div className="p-2">
-        <p className="text-[11px] font-bold text-gray-800 uppercase truncate">
+      <div className="flex flex-col px-1 pt-3 pb-1">
+        {/* Nombre de la ciudad */}
+        <p className="text-[10px] font-extrabold text-[#b48348] uppercase tracking-wider">
           {title}
         </p>
-        <p className="text-[10px] text-gray-500 truncate">
-          {isEmpty ? "No disponible" : location}
+
+        {/* Título de la propiedad */}
+        <p className="text-[15px] font-black text-gray-900 truncate mt-1">
+          {previews.length > 0 && !isEmpty ? currentSlide.titulo : (isEmpty ? "Sin inmuebles" : "Destacados")}
         </p>
 
-        {/* EN VENTA */}
-        {!isAlquiler && count !== undefined && (
-          <div className="flex items-center justify-between mt-1">
-            <span
-              className={`text-[10px] font-semibold ${isEmpty ? "text-gray-400" : "text-orange-500"
-                }`}
-            >
-              {isEmpty ? "Sin propiedades" : `${count.toLocaleString()} Propiedades`}
+        {/* Cantidad de propiedades */}
+        <div className="flex items-center justify-between mt-3">
+          <span className="text-[11px] font-medium text-gray-500">
+            {isEmpty ? "Sin propiedades" : `${count?.toLocaleString()} Propiedades`}
+          </span>
+          {!isEmpty && (
+            <span className="text-[#b48348] text-lg font-bold leading-none translate-x-0 group-hover:translate-x-1 transition-transform">
+              →
             </span>
-            {!isEmpty && (
-              <span className="text-orange-400 text-[10px]">→</span>
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/VisualFilters/VisualFiltersSection.tsx
+++ b/frontend/src/components/VisualFilters/VisualFiltersSection.tsx
@@ -60,6 +60,14 @@ function normalizeName(name: string): string {
   return name.trim().toUpperCase();
 }
 
+function formatImageUrl(imagen: string | undefined): string {
+  if (!imagen) return "";
+  if (imagen.startsWith("http://") || imagen.startsWith("https://") || imagen.startsWith("/")) {
+    return imagen;
+  }
+  return `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000"}/${imagen}`;
+}
+
 function mergeDepartamentos(
   base: string[],
   datos: BackendItem[]
@@ -71,7 +79,10 @@ function mergeDepartamentos(
     return {
       nombre: dept,
       total: found?.count ?? 0,
-      previews: found?.previews ?? [],
+      previews: (found?.previews ?? []).map(p => ({
+        ...p,
+        imagen: formatImageUrl(p.imagen)
+      })),
     };
   });
 

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
  
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -317,7 +317,10 @@ export default function Navbar() {
   };
  
   const handleLoginRedirect = () => router.push("/sign-in");
-  const handleOpenLogoutModal = () => setShowLogoutModal(true);
+  const handleOpenLogoutModal = () => {
+    setShowLogoutModal(true);
+    setIsPanelOpen(false);
+  };
  
   const handleCancelLogout = () => {
     if (isLoggingOut) return;

--- a/frontend/src/components/navbar/UserMenu.tsx
+++ b/frontend/src/components/navbar/UserMenu.tsx
@@ -189,7 +189,7 @@ export default function UserMenu({
       </button>
 
       <div
-        className={`absolute right-0 mt-3 w-72 rounded-xl border border-gray-200 bg-[#F9F6EE] shadow-lg p-5 z-50 transition-all duration-200 ${isPanelOpen ? "opacity-100 translate-y-0 visible" : "opacity-0 -translate-y-2 invisible pointer-events-none"}`}
+        className={`fixed left-1/2 -translate-x-1/2 top-[60px] w-[calc(100vw-2rem)] max-w-[340px] rounded-xl border border-gray-200 bg-[#F9F6EE] shadow-[0_8px_30px_rgba(0,0,0,0.12)] p-5 z-[999] transition-all duration-200 sm:absolute sm:left-auto sm:-translate-x-0 sm:top-auto sm:right-0 sm:mt-3 sm:w-72 ${isPanelOpen ? "opacity-100 translate-y-0 visible" : "opacity-0 -translate-y-4 sm:-translate-y-2 invisible pointer-events-none"}`}
       >
         <div className="flex justify-between items-center mb-4 border-b border-gray-300 pb-2">
           <span className="font-bold text-sm text-gray-900">


### PR DESCRIPTION
Filtros Visuales: Se corrigió la construcción de URLs de las imágenes. Ahora las ciudades sin inmuebles muestran una imagen de fondo por defecto para mantener la consistencia estética.

PropertyCard: Rediseño del componente para alinear la fidelidad visual con Figma (ajuste de tipografías, colores, espaciados internos y bordes redondeados).

Responsive & Bugs: Se arregló el desbordamiento horizontal (overflow) del menú de usuario en móviles pasándolo a un formato modal centrado. Además, se corrigió el solapamiento, forzando el cierre del menú al abrir el modal de "Cerrar Sesión".