### PR TITLE
hotfix: corrección de limpieza de Markdown y refactorizar diseño de la sección de blogs

### DIFF
--- a/frontend/src/components/home/HomeBlogsSection.tsx
+++ b/frontend/src/components/home/HomeBlogsSection.tsx
@@ -7,19 +7,18 @@ export default async function HomeBlogsSection() {
 
   const topBlogs = sortedBlogs.slice(0, 3);
 
-
   return (
     <section className="w-full py-20 px-4 sm:px-6 lg:px-8 max-w-[1400px] mx-auto space-y-24">
       {/* TOP SECTION: BLOGS HEADER */}
       <div className="space-y-12">
-        <div className="flex items-end justify-between border-b border-stone-200 pb-8">
-          <h2 className="font-['Montserrat'] text-6xl font-black uppercase tracking-tighter text-stone-900 sm:text-8xl">
+        <div className="flex flex-col gap-5 border-b border-stone-200 pb-8 sm:flex-row sm:items-end sm:justify-between">
+          <h2 className="font-['Montserrat'] text-5xl font-black uppercase tracking-tighter text-stone-900 sm:text-8xl">
             Blogs
           </h2>
 
           <Link
             href="/blogs"
-            className="hidden sm:block rounded-full bg-[#D97706] px-8 py-3 text-xs font-bold uppercase tracking-widest text-white transition-all hover:bg-stone-900 hover:shadow-xl"
+            className="inline-flex self-start rounded-full bg-[#D97706] px-6 py-3 text-[11px] font-bold uppercase tracking-[0.2em] text-white transition-all hover:bg-stone-900 hover:shadow-xl sm:self-auto sm:px-8 sm:text-xs sm:tracking-widest"
           >
             Explorar Blogs
           </Link>

--- a/frontend/src/lib/blogMarkdown.ts
+++ b/frontend/src/lib/blogMarkdown.ts
@@ -6,6 +6,7 @@ const HEADING_PATTERN = /^\s{0,3}#{1,6}\s+/gm
 const BLOCKQUOTE_PATTERN = /^\s{0,3}>\s?/gm
 const LIST_PATTERN = /^\s*([-*+]|\d+\.)\s+/gm
 const EMPHASIS_PATTERN = /(\*\*|__|\*|_|~~)/g
+const HARD_BREAK_PATTERN = /\\\r?\n/g
 
 export function stripMarkdown(markdown: string): string {
   return markdown
@@ -17,6 +18,7 @@ export function stripMarkdown(markdown: string): string {
     .replace(BLOCKQUOTE_PATTERN, "")
     .replace(LIST_PATTERN, "")
     .replace(EMPHASIS_PATTERN, "")
+    .replace(HARD_BREAK_PATTERN, "\n")
     .replace(/\r\n/g, "\n")
     .replace(/\n{2,}/g, "\n")
     .replace(/[ \t]{2,}/g, " ")


### PR DESCRIPTION
**Hotfix de blogs en homepage:** 
Se habilita el botón Explorar Blogs en vista móvil.
Se corrige la limpieza de excerpts para evitar slash visibles en las tarjetas sin afectar el renderizado Markdown del contenido completo.