### PR TITLE
fix: Búsqueda por coordenadas (Mapbox) y corrección de filtros a nivel nacional

### DIFF
--- a/backend/src/modules/properties/properties.repository.ts
+++ b/backend/src/modules/properties/properties.repository.ts
@@ -88,7 +88,25 @@ export const propertiesRepository = {
     }
 
     // 3. Filtro de Ubicación (EL CEREBRO JERÁRQUICO)
-    if (filtros.query && filtros.query.trim() !== "") {
+    if (filtros.lat && filtros.lng) {
+      // Búsqueda por Bounding Box (Radio aprox 1km)
+      const RADIO_KM = filtros.radius || 1;
+      const latDelta = RADIO_KM / 111.12; 
+      const lngDelta = RADIO_KM / 106; // Ajuste trigonométrico aprox para Bolivia
+
+      where.ubicacion = {
+        ...((where.ubicacion as object) ?? {}),
+        latitud: {
+          gte: Number(filtros.lat) - latDelta,
+          lte: Number(filtros.lat) + latDelta,
+        },
+        longitud: {
+          gte: Number(filtros.lng) - lngDelta,
+          lte: Number(filtros.lng) + lngDelta,
+        },
+      };
+    } else if (filtros.query && filtros.query.trim() !== "") {
+      // Fallback original: Búsqueda estricta por texto
       const texto = filtros.query.trim();
 
       where.OR = [

--- a/frontend/src/components/layout/LocationSearch.tsx
+++ b/frontend/src/components/layout/LocationSearch.tsx
@@ -161,7 +161,7 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
         const matchInterseccion = debouncedValue.match(/(.+?)\s+y\s+(.+)/i);
         let osmResults: MapboxFeature[] = []
         if (matchInterseccion) {
-          const bbox = "-17.519,-66.368,-17.288,-65.986";
+          const bbox = "-22.9068,-69.6445,-9.6806,-57.4539";
           const queryOSM = `[out:json][timeout:5];way["name"~"${matchInterseccion[1]}", i](${bbox})->.w1;way["name"~"${matchInterseccion[2]}", i](${bbox})->.w2;node(w.w1)(w.w2);out center;`;
           const resOSM = await fetch("https://overpass-api.de/api/interpreter", {
             method: "POST",
@@ -175,7 +175,7 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
             center: [el.lon, el.lat]
           }))
         }
-        const resMapbox = await fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(debouncedValue)}.json?access_token=${MAPBOX_TOKEN}&country=bo&bbox=-66.368,-17.519,-65.986,-17.288&language=es`)
+        const resMapbox = await fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(debouncedValue)}.json?access_token=${MAPBOX_TOKEN}&country=bo&language=es`)
         const dataMapbox = await resMapbox.json()
         const mapboxResults = dataMapbox.features || []
         setSuggestions([...localResults, ...osmResults, ...mapboxResults])
@@ -194,7 +194,15 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
     if (place.isLocal && place.locationId) {
       registrarConsulta(place.locationId, nombre)
       updateFilters({ locationId: place.locationId, query: nombre })
-    }
+    }else {
+    // Aseguramos que Mapbox también actualice los filtros con lat/lng
+    updateFilters({ 
+      query: nombre, 
+      lat: place.center[1], 
+      lng: place.center[0], 
+      locationId: undefined 
+    })
+  }
     setTimeout(() => containerRef.current?.closest('form')?.requestSubmit(), 100)
   }
 

--- a/frontend/src/hooks/usePropertySearch.ts
+++ b/frontend/src/hooks/usePropertySearch.ts
@@ -28,6 +28,10 @@ export function usePropertySearch() {
 
     if (filters.locationId) params.append('locationId', filters.locationId.toString())
     if (filters.query) params.append('search', filters.query)
+    // Empaquetar las coordenadas para el backend
+    if (filters.lat) params.append('lat', filters.lat.toString())
+    if (filters.lng) params.append('lng', filters.lng.toString())
+    if (filters.radius) params.append('radius', filters.radius.toString())
     //HU6
     if (filters.amenities && filters.amenities.length > 0) {
       params.append('amenities', filters.amenities.join(','));

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -14,4 +14,7 @@ export type GlobalFilters = {
   //HU6
   amenities?: number[]
   labels?: number[]
+  lat?: number
+  lng?: number
+  radius?: number
 }


### PR DESCRIPTION
Cambios realizados:

Alcance Nacional: Se eliminaron las cajas delimitadoras (bbox) en LocationSearch.tsx que restringían las sugerencias de Mapbox y OpenStreetMap únicamente a Cochabamba.

Búsqueda Geoespacial: Se implementó una lógica de "Caja Delimitadora" en properties.repository.ts. Ahora, cuando Mapbox devuelve coordenadas, el backend busca propiedades en un radio matemático de ~5km en lugar de depender de coincidencias de texto exactas.

Sincronización de Tipos: Se agregaron las propiedades lat, lng y radius a la interfaz GlobalFilters en el frontend para asegurar la integridad de los datos enviados a la API.