### PR TITLE
fix: Ajuste de jerarquía visual (z-index) en la barra de filtros del mapa

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -364,12 +364,11 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
     }
   }
 
-  // 🚀 FIX Z-INDEX MASIVO: Agregamos z-[99999] y !overflow-visible para aplastar al mapa
+  // FIX Z-INDEX MASIVO: Agregamos z-[99999] y !overflow-visible para aplastar al mapa
   const containerStyles =
     variant === 'map'
-      ? 'bg-[#faf9f6] border-b border-stone-200 py-2 px-4 w-full flex flex-col gap-2 shadow-sm sticky top-0 z-50 !overflow-visible'
-      : 'bg-white shadow-lg rounded-[30px] p-6 flex flex-col gap-6 w-full max-w-[921px] relative z-[99999] !overflow-visible'
-
+      ? 'bg-[#faf9f6] border-b border-stone-200 py-2 px-4 w-full flex flex-col gap-2 shadow-sm sticky top-0 z-[9999] !overflow-visible'
+      : 'bg-white shadow-lg rounded-[30px] p-6 flex flex-col gap-6 w-full max-w-[921px] relative z-[999999] !overflow-visible'
   return (
     <form className={containerStyles} onSubmit={handleSearch}>
       


### PR DESCRIPTION
Cambios realizados:

Jerarquía de Capas: Se incrementó el z-index de la variante 'map' en el componente FilterBar.tsx de z-50 a z-[9999].  

Prioridad de Renderizado: Se aplicó la utilidad !overflow-visible de Tailwind para asegurar que el contenedor de la barra de filtros no corte el despliegue de las sugerencias de ubicación frente a otros elementos pegajosos (sticky).