### PR TITLE
fix: Reset completo de estados y limpieza de caché en el botón Limpiar Todos

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -515,10 +515,19 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
                 type="button" 
                 onClick={(e) => {
                   e.preventDefault()
+                  
+                  // 1. Vaciamos todos los estados visuales por completo
                   setTipoInmueble('Cualquier tipo')
-                  setModosSeleccionados(['VENTA'])
+                  setModosSeleccionados([]) // Arreglo vacío para desmarcar todos los checkboxes
                   setUbicacionTexto('')
                   setCoords({})
+                  
+                  // 2. Limpiamos la memoria del navegador para matar los filtros "fantasma"
+                  sessionStorage.removeItem('propbol_global_filters')
+                  sessionStorage.removeItem('propbol_modo_recomendados')
+                  sessionStorage.removeItem('propbol_recomendados')
+                  
+                  // 3. Reseteamos la URL a su estado más puro
                   router.push('/busqueda_mapa')
                 }} 
                 className="text-xs font-bold text-stone-400 hover:text-stone-600 underline ml-auto mr-3 transition-colors"


### PR DESCRIPTION
Cambios realizados:

Reset de Estados: Se actualizó la función onClick del botón para pasar un arreglo vacío [] a setModosSeleccionados, garantizando que todos los checkboxes se desmarquen en el frontend.  

Limpieza de Memoria (Storage): Se añadieron llamadas a sessionStorage.removeItem para eliminar las llaves propbol_global_filters, propbol_modo_recomendados y propbol_recomendados. Esto evita que filtros antiguos se vuelvan a aplicar automáticamente al recargar la página.  

Consistencia de URL: Se simplificó la navegación hacia /busqueda_mapa para asegurar que el usuario comience una sesión de búsqueda limpia desde cero.