### PR TITLE
fix: Optimización de búsqueda geográfica y corrección de radio restrictivo

### DIFF
--- a/frontend/src/components/filters/FilterBar.tsx
+++ b/frontend/src/components/filters/FilterBar.tsx
@@ -58,6 +58,7 @@ type LocationValue =
     nombre: string
     lat?: number
     lng?: number
+    locationId?: number
   }
 
 // Botón Mock
@@ -370,7 +371,12 @@ export default function FilterBar({ onSearch, variant = 'home', onOpenPriceFilte
   const handleLocationChange = (val: LocationValue) => {
     if (typeof val === 'object' && val !== null) {
       setUbicacionTexto(val.nombre)
-      setCoords({ lat: val.lat, lng: val.lng })
+      if (val.locationId) {
+        // Si tenemos locationId, VACIAMOS las coordenadas para que el backend busque en toda la zona
+        setCoords({}) 
+      } else {
+        setCoords({ lat: val.lat, lng: val.lng })
+      }
     } else {
       setUbicacionTexto(val as string)
       setCoords({}) // Si es solo texto del historial, borramos las coordenadas

--- a/frontend/src/components/layout/LocationSearch.tsx
+++ b/frontend/src/components/layout/LocationSearch.tsx
@@ -185,24 +185,31 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
     searchAll()
   }, [debouncedValue, API_BASE, MAPBOX_TOKEN])
 
-  const handleSelect = (place: MapboxFeature) => {
+const handleSelect = (place: MapboxFeature) => {
     const nombre = place.text
     setInputValue(nombre)
     saveToHistory(nombre)
     setIsOpen(false)
-    onChange({ nombre, lat: place.center[1] !== 0 ? place.center[1] : undefined, lng: place.center[0] !== 0 ? place.center[0] : undefined, locationId: place.locationId })
+    
     if (place.isLocal && place.locationId) {
+      // Es zona oficial de PropBol. Usamos locationId y NO enviamos coordenadas.
+      onChange({ nombre, locationId: place.locationId })
       registrarConsulta(place.locationId, nombre)
-      updateFilters({ locationId: place.locationId, query: nombre })
-    }else {
-    // Aseguramos que Mapbox también actualice los filtros con lat/lng
-    updateFilters({ 
-      query: nombre, 
-      lat: place.center[1], 
-      lng: place.center[0], 
-      locationId: undefined 
-    })
-  }
+      updateFilters({ locationId: place.locationId, query: nombre, lat: undefined, lng: undefined })
+    } else {
+      // Es una calle de Mapbox. Usamos coordenadas.
+      onChange({ 
+        nombre, 
+        lat: place.center[1] !== 0 ? place.center[1] : undefined, 
+        lng: place.center[0] !== 0 ? place.center[0] : undefined 
+      })
+      updateFilters({ 
+        query: nombre, 
+        lat: place.center[1], 
+        lng: place.center[0], 
+        locationId: undefined 
+      })
+    }
     setTimeout(() => containerRef.current?.closest('form')?.requestSubmit(), 100)
   }
 
@@ -248,13 +255,16 @@ export function LocationSearch({ value, onChange }: LocationSearchProps) {
         }
       }
 
-      // 3. Pasar los datos completos (con coordenadas) al FilterBar
+      // 3. Pasar los datos completos (con coordenadas o locationId) al FilterBar
       if (bestMatch) {
-        onChange(bestMatch)
         if (isLocal && bestMatch.locationId) {
+          // Historial de zona oficial de PropBol (Sin coordenadas)
+          onChange({ nombre: bestMatch.nombre, locationId: bestMatch.locationId })
           registrarConsulta(bestMatch.locationId, bestMatch.nombre)
-          updateFilters({ locationId: bestMatch.locationId, query: bestMatch.nombre })
+          updateFilters({ locationId: bestMatch.locationId, query: bestMatch.nombre, lat: undefined, lng: undefined })
         } else {
+          // Historial de calle de Mapbox (Con coordenadas)
+          onChange({ nombre: bestMatch.nombre, lat: bestMatch.lat, lng: bestMatch.lng })
           updateFilters({
             query: bestMatch.nombre,
             lat: bestMatch.lat,


### PR DESCRIPTION
Cambios realizados:

Lógica de Búsqueda Híbrida: Se modificó LocationSearch para detectar si el usuario selecciona una zona local (con locationId) o una ubicación externa (Mapbox). Si es local, se omiten las coordenadas para permitir que el backend devuelva todos los inmuebles de la zona sin restricciones de distancia.

Ampliación del Radio de Búsqueda: Para búsquedas en puntos específicos de Mapbox (como calles o intersecciones), se aumentó el radio de búsqueda de 1km a 3km en FilterBar.tsx, proporcionando resultados más relevantes en áreas menos densas.

Sincronización de Coordenadas: Se actualizó handleLocationChange para limpiar los estados de lat y lng cuando se selecciona una zona oficial, forzando la búsqueda por jerarquía territorial y no por proximidad radial.

Interfaz de Tipos: Se extendió la interfaz LocationValue para incluir locationId, asegurando la integridad de los datos entre componentes.