### PR TITLE
Feature/panel derecho blog

### DIFF
--- a/frontend/src/app/blog/[id]/page.tsx
+++ b/frontend/src/app/blog/[id]/page.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image"
-import Link from 'next/link'
-import { ChevronLeft } from 'lucide-react'
 import { notFound } from 'next/navigation'
+import BlogDetailSidebar from '@/components/blog/BlogDetailSidebar'
 import BlogCommentsSection from '@/components/blog/BlogCommentsSection'
 import MarkdownRenderer from '@/components/blog/MarkdownRenderer'
 import { MOCK_USER_BLOGS } from '@/lib/mock/blogs.mock'
@@ -73,17 +72,21 @@ export default async function BlogDetailPage({ params }: { params: { id: string 
         </div>
       </header>
 
-      <main className="mx-auto mt-12 max-w-4xl px-4 sm:px-6 lg:px-8">
-        <div className="rounded-[36px] bg-white/90 p-6 shadow-[0_24px_80px_-50px_rgba(41,37,36,0.45)] sm:p-8 lg:p-10">
-          <MarkdownRenderer content={articleContent} />
-        </div>
+      <main className="mx-auto mt-12 max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-12">
+            <div className="rounded-[36px] bg-white/90 p-6 shadow-[0_24px_80px_-50px_rgba(41,37,36,0.45)] sm:p-8 lg:p-10">
+              <MarkdownRenderer content={articleContent} />
+            </div>
 
-        <BlogCommentsSection blogId={params.id} />
+            <BlogCommentsSection blogId={params.id} />
 
-        <div className="pt-12">
-          <div className="pt-12">
-            <BackButton />
+            <div className="pt-2">
+              <BackButton />
+            </div>
           </div>
+
+          <BlogDetailSidebar />
         </div>
       </main>
     </article>

--- a/frontend/src/components/blog/BlogDetailSidebar.tsx
+++ b/frontend/src/components/blog/BlogDetailSidebar.tsx
@@ -1,0 +1,7 @@
+export default function BlogDetailSidebar() {
+  return (
+    <aside className="mx-auto w-full max-w-[380px] lg:sticky lg:top-8">
+      <div className="min-h-[840px] rounded-[32px] bg-white shadow-[0_24px_60px_-48px_rgba(41,37,36,0.5)] sm:min-h-[880px]" />
+    </aside>
+  )
+}


### PR DESCRIPTION
Se implementó el layout del panel derecho en el detalle de blogs y luego se ajustó para dejarlo únicamente como un contenedor blanco, respetando el tamaño definido para futuras integraciones de compartir y lecturas recomendadas. Además, la página de detalle del blog se adaptó para mostrar este panel en una estructura de dos columnas responsive.