### PR TITLE
Feature/homepage cambio referencial

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,15 +5,9 @@ import { getCities } from '@/services/city.service'
 import dynamic from 'next/dynamic'
 import VisualFiltersSection from '@/components/VisualFilters/VisualFiltersSection'
 import HomeBlogsSection from '@/components/home/HomeBlogsSection'
-import ExchangeRateBar from '@/components/ExchangeRateBar'
+import HomeExchangeSection from '@/components/home/HomeExchangeSection'
 
 const TourGuiado = dynamic(() => import('@/components/ui/TourGuiado'), { ssr: false })
-
-const mockExchangeRate = {
-  officialRate: 6.96,
-  referentialRate: 11.5,
-  updatedAt: "4/5/2026",
-}
 
 interface BannerRaw {
   id: number;
@@ -74,11 +68,7 @@ export default async function Home() {
         </div>
       )}
 
-      <ExchangeRateBar
-        officialRate={mockExchangeRate.officialRate}
-        referentialRate={mockExchangeRate.referentialRate}
-        updatedAt={mockExchangeRate.updatedAt}
-      />
+      <HomeExchangeSection />
 
       <div className="w-full max-w-[1600px] mx-auto px-0 md:px-4 py-4">
         <div className="flex flex-col gap-0">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,8 +5,15 @@ import { getCities } from '@/services/city.service'
 import dynamic from 'next/dynamic'
 import VisualFiltersSection from '@/components/VisualFilters/VisualFiltersSection'
 import HomeBlogsSection from '@/components/home/HomeBlogsSection'
+import ExchangeRateBar from '@/components/ExchangeRateBar'
 
 const TourGuiado = dynamic(() => import('@/components/ui/TourGuiado'), { ssr: false })
+
+const mockExchangeRate = {
+  officialRate: 6.96,
+  referentialRate: 11.5,
+  updatedAt: "4/5/2026",
+}
 
 interface BannerRaw {
   id: number;
@@ -66,6 +73,12 @@ export default async function Home() {
           <p className="text-gray-600">No hay banners disponibles</p>
         </div>
       )}
+
+      <ExchangeRateBar
+        officialRate={mockExchangeRate.officialRate}
+        referentialRate={mockExchangeRate.referentialRate}
+        updatedAt={mockExchangeRate.updatedAt}
+      />
 
       <div className="w-full max-w-[1600px] mx-auto px-0 md:px-4 py-4">
         <div className="flex flex-col gap-0">

--- a/frontend/src/components/ExchangeRateBar.tsx
+++ b/frontend/src/components/ExchangeRateBar.tsx
@@ -2,7 +2,7 @@ import { ArrowDownRight, ArrowUpRight, BadgeDollarSign, Info } from "lucide-reac
 
 interface ExchangeRateBarProps {
   officialRate: number;
-  referentialRate: number;
+  referentialRate: number | null;
   updatedAt: string;
   isLoading?: boolean;
 }
@@ -13,8 +13,8 @@ export default function ExchangeRateBar({
   updatedAt,
   isLoading = false,
 }: ExchangeRateBarProps) {
-  const isHigher = referentialRate > officialRate;
-  const isLower = referentialRate < officialRate;
+  const isHigher = referentialRate !== null && referentialRate > officialRate;
+  const isLower = referentialRate !== null && referentialRate < officialRate;
   const TrendIcon = isHigher ? ArrowUpRight : ArrowDownRight;
 
   if (isLoading) {
@@ -35,7 +35,11 @@ export default function ExchangeRateBar({
           <span className="flex items-center gap-2 font-medium"><BadgeDollarSign className="h-4 w-4 text-emerald-600" />Tipo de Cambio:</span>
           <span>Oficial: <strong className="text-stone-900">Bs {officialRate.toFixed(2)}</strong></span>
           <span className="hidden text-stone-300 sm:inline">|</span>
-          <span className="flex items-center gap-1 text-[#D97706]">Referencial: <strong>Bs {referentialRate.toFixed(2)}</strong>{(isHigher || isLower) && <TrendIcon className="h-4 w-4" />}</span>
+          <span className="flex items-center gap-1 text-[#D97706]">
+            Referencial:{" "}
+            <strong>{referentialRate === null ? "No disponible" : `Bs ${referentialRate.toFixed(2)}`}</strong>
+            {(isHigher || isLower) && <TrendIcon className="h-4 w-4" />}
+          </span>
         </div>
 
         <div className="flex items-center gap-2 text-xs text-stone-500 sm:text-sm">

--- a/frontend/src/components/ExchangeRateBar.tsx
+++ b/frontend/src/components/ExchangeRateBar.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ArrowDownRight, ArrowUpRight, BadgeDollarSign, Info } from "lucide-react";
 
 interface ExchangeRateBarProps {
@@ -41,8 +39,12 @@ export default function ExchangeRateBar({
         </div>
 
         <div className="flex items-center gap-2 text-xs text-stone-500 sm:text-sm">
-          <div className="group relative flex items-center">
-            <Info aria-label="Información sobre tipo de cambio" className="h-4 w-4" />
+          <div
+            className="group relative flex items-center"
+            aria-label="Información sobre tipo de cambio"
+            title="Información sobre tipo de cambio"
+          >
+            <Info className="h-4 w-4" />
             <div className="pointer-events-none absolute right-0 top-6 z-10 hidden w-64 rounded-2xl bg-stone-900 px-4 py-3 text-left text-xs leading-5 text-white shadow-xl group-hover:block group-focus-within:block">
               El tipo oficial es el valor regulado. El referencial refleja un valor de mercado actualizado.
             </div>

--- a/frontend/src/components/ExchangeRateBar.tsx
+++ b/frontend/src/components/ExchangeRateBar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ArrowDownRight, ArrowUpRight, BadgeDollarSign, Info } from "lucide-react";
+
+interface ExchangeRateBarProps {
+  officialRate: number;
+  referentialRate: number;
+  updatedAt: string;
+  isLoading?: boolean;
+}
+
+export default function ExchangeRateBar({
+  officialRate,
+  referentialRate,
+  updatedAt,
+  isLoading = false,
+}: ExchangeRateBarProps) {
+  const isHigher = referentialRate > officialRate;
+  const isLower = referentialRate < officialRate;
+  const TrendIcon = isHigher ? ArrowUpRight : ArrowDownRight;
+
+  if (isLoading) {
+    return (
+      <section aria-label="Cargando tipo de cambio" className="w-full border-b border-stone-200 bg-white/95">
+        <div className="mx-auto flex max-w-[1600px] animate-pulse flex-col gap-3 px-4 py-3 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="h-4 w-64 rounded-full bg-stone-200" />
+          <div className="h-4 w-36 rounded-full bg-stone-200" />
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Barra referencial de tipo de cambio" className="w-full border-b border-stone-200 bg-white/95">
+      <div className="mx-auto flex max-w-[1600px] flex-col gap-3 px-4 py-3 text-sm text-stone-600 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <span className="flex items-center gap-2 font-medium"><BadgeDollarSign className="h-4 w-4 text-emerald-600" />Tipo de Cambio:</span>
+          <span>Oficial: <strong className="text-stone-900">Bs {officialRate.toFixed(2)}</strong></span>
+          <span className="hidden text-stone-300 sm:inline">|</span>
+          <span className="flex items-center gap-1 text-[#D97706]">Referencial: <strong>Bs {referentialRate.toFixed(2)}</strong>{(isHigher || isLower) && <TrendIcon className="h-4 w-4" />}</span>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-stone-500 sm:text-sm">
+          <div className="group relative flex items-center">
+            <Info aria-label="Información sobre tipo de cambio" className="h-4 w-4" />
+            <div className="pointer-events-none absolute right-0 top-6 z-10 hidden w-64 rounded-2xl bg-stone-900 px-4 py-3 text-left text-xs leading-5 text-white shadow-xl group-hover:block group-focus-within:block">
+              El tipo oficial es el valor regulado. El referencial refleja un valor de mercado actualizado.
+            </div>
+          </div>
+          <span>Actualizado al {updatedAt}</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/home/HomeExchangeSection.tsx
+++ b/frontend/src/components/home/HomeExchangeSection.tsx
@@ -1,0 +1,17 @@
+import ExchangeRateBar from "@/components/ExchangeRateBar";
+
+const mockExchangeRate = {
+  officialRate: 6.96,
+  referentialRate: 11.5,
+  updatedAt: "4/5/2026",
+};
+
+export default function HomeExchangeSection() {
+  return (
+    <ExchangeRateBar
+      officialRate={mockExchangeRate.officialRate}
+      referentialRate={mockExchangeRate.referentialRate}
+      updatedAt={mockExchangeRate.updatedAt}
+    />
+  );
+}


### PR DESCRIPTION
**Cambios realizados:**

- Props tipadas con interface explícita: { officialRate: number; referentialRate: number | null; updatedAt: string; isLoading?: boolean }.
- El componente solo renderiza: barra, tooltip informativo, icono de tendencia (subida/bajada) y skeleton de carga.
- No hace fetch, no lee process.env, no contiene lógica de negocio.
- Mock inyectado desde HomeExchangeSection.tsx, page.tsx no crece con lógica.
- Incluir accesibilidad (aria-label) y responsive desde esta tarea.