### PR TITLE
Feature/hu02 exchange rate

### DIFF
--- a/docs/cache-strategy.md
+++ b/docs/cache-strategy.md
@@ -1,0 +1,13 @@
+# Estrategia de Caché: Tipo de Cambio Referencial
+
+## 1. Funcionamiento del Revalidate (Caché Principal)
+La implementación usa el caché nativo de Next.js (`revalidate: 1800`). El sistema es estrictamente on-demand: si nadie entra al Home, no se hacen peticiones a P2P.Army.
+- **Menos de 30 minutos:** Next.js sirve el valor desde su caché interno instantáneamente sin consumir red.
+- **Más de 30 minutos (Expirado):** Next.js sirve el último valor conocido al instante para no bloquear al usuario, y dispara una petición en background para actualizar el dato.
+
+## 2. Instancia en Memoria (Fallback / Cold Start)
+En el archivo `exchangeRateService.ts` se utilizará una variable global (`let moduleCache`). Esta variable actúa como una instancia en memoria que vive mientras el servidor Node.js/Next.js esté en ejecución.
+- Si ocurre un *Cold Start* (el servidor despierta y el caché de Next.js está vacío) y P2P.Army rechaza la conexión, el servicio utilizará el valor guardado en `moduleCache` como red de seguridad para evitar que la UI falle.
+
+## 3. Justificación: Por qué NO se usa Supabase
+El proyecto cuenta con un plan limitado de base de datos en Supabase. Utilizar una tabla para guardar un solo número (el tipo de cambio) que se consulta en la página de mayor tráfico (el Home) generaría un exceso de lecturas/escrituras injustificado. La combinación del Data Cache de Next.js + la instancia en memoria (`moduleCache`) resuelve el problema con 0 llamadas a la base de datos y 0 costo adicional.

--- a/docs/spike-binance.md
+++ b/docs/spike-binance.md
@@ -1,0 +1,20 @@
+# Spike: API de Binance P2P (USDT/BOB)
+
+## 1. Objetivo
+Validar el endpoint público de Binance P2P para obtener el tipo de cambio referencial (USDT/BOB) sin autenticación para la HU-02.
+
+## 2. Endpoint Validado
+- **URL Base:** `https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search`
+- **Método:** `POST`
+
+## 3. Ejemplo de cURL (Request)
+```bash
+curl -X POST "[https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search](https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search)" \
+     -H "Content-Type: application/json" \
+     -d '{"fiat": "BOB", "asset": "USDT", "tradeType": "SELL", "page": 1, "rows": 1, "payTypes": [], "publisherType": null}'
+4. Decisión Técnica
+Extracción: El precio viene en response.data[0].adv.price.
+
+Caché: Se usará el caché nativo de Next.js (revalidate: 1800) en la Tarea 3 para evitar bloqueos por IP.
+
+Base de Datos: No será necesario usar Supabase para guardar este dato gracias al caché de Next.js.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,14 @@
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=tu_google_client_id
+NEXT_PUBLIC_API_URL=https://propbol-tsiq.onrender.com
+NEXT_PUBLIC_MAPBOX_TOKEN=tu_mapbox_token
+
+# --- TIPO DE CAMBIO (HU-02) ---
+
+# Tipo oficial fijo (Bs 6.96). Solo cambiar si el BCB actualiza. NUNCA por código.
+OFFICIAL_EXCHANGE_RATE=6.96
+
+# P2P.Army API - Endpoint dedicado
+P2P_ARMY_API_URL=https://p2p.army/v1/api/get_p2p_prices
+
+# API key privada de P2P.Army (Registrarse en p2p.army/en/api_p2p para obtener key gratuita)
+P2P_ARMY_API_KEY=tu_api_key_aqui_placeholder


### PR DESCRIPTION

Implementación de la HU-02 para mostrar el tipo de cambio en el Home. Se usa la API de P2P.Army con caché nativa de Next.js (`revalidate: 1800`) y un módulo en memoria. **Cero llamadas a Supabase** para proteger el plan gratuito.




## 🛑 Nota para el equipo
Por favor, **configuren su archivo `.env` local** usando los nuevos datos del `.env.example`, de lo contrario la conexión a la API fallará en sus computadoras.