### PR TITLE
feat(logic): setup de busqueda base y filtrado por ubicacion - T1 fin

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -46,6 +46,7 @@ import SuperficieFilterSidebar from '@/components/filters/SuperficieFilterSideba
 import { UbicacionEspecificaPanel } from '@/components/filters/UbicacionEspecificaPanel';
 import ComparatorModal from '@/components/busqueda/ComparatorModal'
 import EtiquetasSidebar from '@/components/filters/EtiquetasSidebar'
+import { useSearchFilters, BusquedaModo } from '@/hooks/useSearchFilters'
 
 // Carga dinámica del mapa (sin SSR)
 const MapView = nextDynamic(() => import('./MapView'), {
@@ -147,6 +148,11 @@ function BusquedaMapaContent() {
   const searchParams = useSearchParams();
   const isRecomendadosActive = searchParams.get('orden') === 'recomendados'
   const filterResetKey = searchParams.toString();
+  
+const { getBusquedaModo, cambiarAModoGeneral } = useSearchFilters()
+const busquedaModo: BusquedaModo = getBusquedaModo(
+  new URLSearchParams(searchParams.toString())
+)
   const minSuperficie = searchParams.get('minSuperficie')
   const maxSuperficie = searchParams.get('maxSuperficie')
   const tieneFiltrSuperficie = minSuperficie || maxSuperficie
@@ -1510,6 +1516,27 @@ function BusquedaMapaContent() {
                         ? 'Recomendados para tí'
                         : 'Resultados de búsqueda'}
                     </h1>
+                    {/* AC 1 & 8 — Toggle modo búsqueda */}
+                     <button
+                onClick={() => {
+               if (busquedaModo === 'especifica') {
+               cambiarAModoGeneral(router, new URLSearchParams(searchParams.toString()))
+          } else {
+               setIsPriceFilterOpen(false)
+                setIsSidebarOpen(true)
+      setActiveSidebarView('ubicacion')
+              }
+                  }}
+              className={`self-start text-xs px-2.5 py-1 rounded-full border transition-all mt-1 mb-2 ${
+    busquedaModo === 'especifica'
+      ? 'bg-orange-50 border-orange-300 text-orange-600 font-medium hover:bg-orange-100'
+      : 'bg-stone-100 border-stone-200 text-stone-500 hover:border-stone-300'
+             }`}
+              >
+             {busquedaModo === 'especifica'
+                ? '📍 Ubicación específica · cambiar a todo Bolivia'
+                  : '🌍 Todo Bolivia · buscar en zona específica'}
+               </button>
 
                     {/* Subtítulo: N Propiedades (Se compacta de sm a xs) */}
                     <h2 className={`font-bold text-slate-900 transition-all duration-300 truncate flex items-center gap-2 ${isScrolled ? 'text-xs mt-0.5' : 'text-sm mt-1'}`}>

--- a/frontend/src/hooks/useSearchFilters.ts
+++ b/frontend/src/hooks/useSearchFilters.ts
@@ -1,25 +1,60 @@
 // -- BitPro
+import { useRouter } from 'next/navigation'
 import { GlobalFilters } from '../types/filters'
 
-export const useSearchFilters = () => {
-  const updateFilters = (newFilter: Partial<GlobalFilters>) => {
-    // 1. Leemos los filtros actuales (si es que hay)
-    const currentFilters: GlobalFilters = JSON.parse(
-      sessionStorage.getItem('propbol_global_filters') || '{}'
-    )
+const FILTER_KEY = 'propbol_global_filters'
 
-    // 2. Creamos un nuevo objeto con los filtros actualizados
+export const FILTROS_URL_KEYS = [
+  'lat', 'lng', 'radio',
+  'departamentoId', 'provinciaId', 'municipioId', 'zonaId', 'barrioId',
+  'precioMin', 'precioMax', 'currency',
+  'dormitoriosMin', 'dormitoriosMax', 'banosMin', 'banosMax', 'tipoBano',
+  'minSuperficie', 'maxSuperficie',
+  'tipo', 'categoria', 'q',
+  'amenities', 'labels',
+] as const
+
+export const UBICACION_URL_KEYS = [
+  'lat', 'lng', 'radio',
+  'departamentoId', 'provinciaId', 'municipioId', 'zonaId', 'barrioId',
+] as const
+
+export type BusquedaModo = 'general' | 'especifica'
+
+export const useSearchFilters = () => {
+
+  const updateFilters = (newFilter: Partial<GlobalFilters>) => {
+    const currentFilters: GlobalFilters = JSON.parse(
+      sessionStorage.getItem(FILTER_KEY) || '{}'
+    )
     const updated = {
       ...currentFilters,
       ...newFilter,
       updatedAt: new Date().toISOString()
     }
-
-    // 3. Guardamos en sessionStorage (podría ser localStorage, pero queremos que se resetee al cerrar la pestaña)
-    sessionStorage.setItem('propbol_global_filters', JSON.stringify(updated))
-
+    sessionStorage.setItem(FILTER_KEY, JSON.stringify(updated))
     window.dispatchEvent(new Event('filterUpdate'))
   }
 
-  return { updateFilters }
+  // AC 1 & 8
+  const getBusquedaModo = (searchParams: URLSearchParams): BusquedaModo => {
+    const tieneUbicacion = UBICACION_URL_KEYS.some((key) => searchParams.has(key))
+    return tieneUbicacion ? 'especifica' : 'general'
+  }
+
+  const cambiarAModoGeneral = (
+    router: ReturnType<typeof useRouter>,
+    currentParams: URLSearchParams
+  ) => {
+    const newParams = new URLSearchParams(currentParams.toString())
+    UBICACION_URL_KEYS.forEach((key) => newParams.delete(key))
+    router.push(`/busqueda_mapa?${newParams.toString()}`)
+    window.dispatchEvent(new Event('filterUpdate'))
+  }
+
+  return {
+    updateFilters,
+    getBusquedaModo,
+    cambiarAModoGeneral,
+  }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la lógica base de búsqueda y el selector de modo geográfico (AC 1 y AC 8).

## Cambios
- `useSearchFilters.ts` — Añade constantes `FILTROS_URL_KEYS` y `UBICACION_URL_KEYS`, el tipo `BusquedaModo` y las funciones `getBusquedaModo()` y `cambiarAModoGeneral()`
- `page.tsx` — Instancia el hook y renderiza el botón toggle entre modo "Todo Bolivia" y "Ubicación específica"

## Cómo probar
1. Entrar a `/busqueda_mapa` sin filtros → debe mostrar "🌍 Todo Bolivia"
2. Seleccionar una ubicación (departamento/municipio) → debe cambiar a "📍 Ubicación específica"
3. Hacer click en el botón → debe volver a modo general limpiando los params de ubicación

