### PR TITLE
feat(logic): observador de ubicacion e integracion de carga-T2 terminado

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -46,6 +46,7 @@ import SuperficieFilterSidebar from '@/components/filters/SuperficieFilterSideba
 import { UbicacionEspecificaPanel } from '@/components/filters/UbicacionEspecificaPanel';
 import ComparatorModal from '@/components/busqueda/ComparatorModal'
 import EtiquetasSidebar from '@/components/filters/EtiquetasSidebar'
+import { useSearchFilters, BusquedaModo } from '@/hooks/useSearchFilters'
 
 // Carga dinámica del mapa (sin SSR)
 const MapView = nextDynamic(() => import('./MapView'), {
@@ -147,6 +148,11 @@ function BusquedaMapaContent() {
   const searchParams = useSearchParams();
   const isRecomendadosActive = searchParams.get('orden') === 'recomendados'
   const filterResetKey = searchParams.toString();
+  
+const { getBusquedaModo, cambiarAModoGeneral } = useSearchFilters()
+const busquedaModo: BusquedaModo = getBusquedaModo(
+  new URLSearchParams(searchParams.toString())
+)
   const minSuperficie = searchParams.get('minSuperficie')
   const maxSuperficie = searchParams.get('maxSuperficie')
   const tieneFiltrSuperficie = minSuperficie || maxSuperficie
@@ -1510,6 +1516,27 @@ function BusquedaMapaContent() {
                         ? 'Recomendados para tí'
                         : 'Resultados de búsqueda'}
                     </h1>
+                    {/* AC 1 & 8 — Toggle modo búsqueda */}
+                     <button
+                onClick={() => {
+               if (busquedaModo === 'especifica') {
+               cambiarAModoGeneral(router, new URLSearchParams(searchParams.toString()))
+          } else {
+               setIsPriceFilterOpen(false)
+                setIsSidebarOpen(true)
+      setActiveSidebarView('ubicacion')
+              }
+                  }}
+              className={`self-start text-xs px-2.5 py-1 rounded-full border transition-all mt-1 mb-2 ${
+    busquedaModo === 'especifica'
+      ? 'bg-orange-50 border-orange-300 text-orange-600 font-medium hover:bg-orange-100'
+      : 'bg-stone-100 border-stone-200 text-stone-500 hover:border-stone-300'
+             }`}
+              >
+             {busquedaModo === 'especifica'
+                ? '📍 Ubicación específica · cambiar a todo Bolivia'
+                  : '🌍 Todo Bolivia · buscar en zona específica'}
+               </button>
 
                     {/* Subtítulo: N Propiedades (Se compacta de sm a xs) */}
                     <h2 className={`font-bold text-slate-900 transition-all duration-300 truncate flex items-center gap-2 ${isScrolled ? 'text-xs mt-0.5' : 'text-sm mt-1'}`}>

--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -611,6 +611,23 @@ const busquedaModo: BusquedaModo = getBusquedaModo(
     return inmueblesOrdenados.slice(start, start + listPageSize);
   }, [inmueblesOrdenados, listSafePage, listPageSize, listTotal]);
 
+// Limpia clusters y paginación cuando cambia la zona geográfica
+const ubicacionKey = [
+  searchParams.get('departamentoId'),
+  searchParams.get('provinciaId'),
+  searchParams.get('municipioId'),
+  searchParams.get('zonaId'),
+  searchParams.get('barrioId'),
+  searchParams.get('lat'),
+  searchParams.get('lng'),
+].join('|')
+
+useEffect(() => {
+  setIsClusterView(false)
+  setClusterProperties([])
+  setActiveClusterIds([])
+  setListPage(1)
+}, [ubicacionKey])
   useEffect(() => {
     setListPage(1);
   }, [filterResetKey, drawnPolygons]);

--- a/frontend/src/hooks/useSearchFilters.ts
+++ b/frontend/src/hooks/useSearchFilters.ts
@@ -1,25 +1,60 @@
 // -- BitPro
+import { useRouter } from 'next/navigation'
 import { GlobalFilters } from '../types/filters'
 
-export const useSearchFilters = () => {
-  const updateFilters = (newFilter: Partial<GlobalFilters>) => {
-    // 1. Leemos los filtros actuales (si es que hay)
-    const currentFilters: GlobalFilters = JSON.parse(
-      sessionStorage.getItem('propbol_global_filters') || '{}'
-    )
+const FILTER_KEY = 'propbol_global_filters'
 
-    // 2. Creamos un nuevo objeto con los filtros actualizados
+export const FILTROS_URL_KEYS = [
+  'lat', 'lng', 'radio',
+  'departamentoId', 'provinciaId', 'municipioId', 'zonaId', 'barrioId',
+  'precioMin', 'precioMax', 'currency',
+  'dormitoriosMin', 'dormitoriosMax', 'banosMin', 'banosMax', 'tipoBano',
+  'minSuperficie', 'maxSuperficie',
+  'tipo', 'categoria', 'q',
+  'amenities', 'labels',
+] as const
+
+export const UBICACION_URL_KEYS = [
+  'lat', 'lng', 'radio',
+  'departamentoId', 'provinciaId', 'municipioId', 'zonaId', 'barrioId',
+] as const
+
+export type BusquedaModo = 'general' | 'especifica'
+
+export const useSearchFilters = () => {
+
+  const updateFilters = (newFilter: Partial<GlobalFilters>) => {
+    const currentFilters: GlobalFilters = JSON.parse(
+      sessionStorage.getItem(FILTER_KEY) || '{}'
+    )
     const updated = {
       ...currentFilters,
       ...newFilter,
       updatedAt: new Date().toISOString()
     }
-
-    // 3. Guardamos en sessionStorage (podría ser localStorage, pero queremos que se resetee al cerrar la pestaña)
-    sessionStorage.setItem('propbol_global_filters', JSON.stringify(updated))
-
+    sessionStorage.setItem(FILTER_KEY, JSON.stringify(updated))
     window.dispatchEvent(new Event('filterUpdate'))
   }
 
-  return { updateFilters }
+  // AC 1 & 8
+  const getBusquedaModo = (searchParams: URLSearchParams): BusquedaModo => {
+    const tieneUbicacion = UBICACION_URL_KEYS.some((key) => searchParams.has(key))
+    return tieneUbicacion ? 'especifica' : 'general'
+  }
+
+  const cambiarAModoGeneral = (
+    router: ReturnType<typeof useRouter>,
+    currentParams: URLSearchParams
+  ) => {
+    const newParams = new URLSearchParams(currentParams.toString())
+    UBICACION_URL_KEYS.forEach((key) => newParams.delete(key))
+    router.push(`/busqueda_mapa?${newParams.toString()}`)
+    window.dispatchEvent(new Event('filterUpdate'))
+  }
+
+  return {
+    updateFilters,
+    getBusquedaModo,
+    cambiarAModoGeneral,
+  }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el observador reactivo de cambios de ubicación 

## Cambios
- `page.tsx` — Añade `ubicacionKey` y un `useEffect` que limpia el estado 
de clusters y paginación automáticamente al cambiar la zona geográfica

## Cómo probar
1. Entrar a `/busqueda_mapa` con una ubicación seleccionada
2. Cambiar a otra ubicación diferente
3. Verificar que los clusters anteriores desaparecen y la lista vuelve a página 1

## Notas
- `useProperties` ya era reactivo a `searchParamsStr`, este PR solo limpia 
el estado visual derivado (clusters, paginación)