### PR TITLE
feat(publicacion): agregar base backend para tutorial previo a creación de inmueble

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Usuario {
   verificacion_pago                     verificacion_pago[]
   visitor                               Visitor[]
   zona_usuario                          zona_usuario[]
+  tutorialPublicacion                   TutorialPublicacionUsuario?
 
   @@index([correo], map: "idx_usuario_correo")
   @@index([rolId], map: "idx_usuario_rol")
@@ -811,6 +812,18 @@ model testimonio_like {
   usuario       Usuario    @relation(fields: [usuario_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([testimonio_id, usuario_id], map: "uq_testimonio_like")
+}
+
+model TutorialPublicacionUsuario {
+  id            Int       @id @default(autoincrement())
+  usuarioId     Int       @unique @map("usuario_id")
+  confirmado    Boolean   @default(false)
+  vistoEn       DateTime? @map("visto_en") @db.Timestamp(6)
+  confirmadoEn  DateTime? @map("confirmado_en") @db.Timestamp(6)
+
+  usuario Usuario @relation(fields: [usuarioId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@map("tutorial_publicacion_usuario")
 }
 
 enum Genero {

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.constants.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.constants.ts
@@ -1,0 +1,11 @@
+import type { TutorialPublicacionContent } from './tutorial-publicacion.types.js'
+
+export const TUTORIAL_PUBLICACION_CONTENT: TutorialPublicacionContent = {
+  titulo: 'Antes de publicar tu propiedad',
+  mensaje:
+    'Ten listos los datos generales del inmueble, ubicación, precio, características principales y contenido multimedia antes de iniciar la publicación.',
+  videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  thumbnailUrl: null,
+  subtitlesUrl: null,
+  checkboxLabel: 'Sí entiendo qué necesito para publicar una propiedad'
+} 

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.controller.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.controller.ts
@@ -1,0 +1,101 @@
+import type { Request, Response } from 'express'
+import {
+  confirmTutorialPublicacionService,
+  getTutorialPublicacionContentService,
+  getTutorialPublicacionEstadoService
+} from './tutorial-publicacion.service.js'
+
+type AuthenticatedRequest = Request & {
+  user?: {
+    id?: number
+  }
+}
+
+const getAuthenticatedUserId = (req: AuthenticatedRequest): number => {
+  const usuarioId = Number(req.user?.id)
+
+  if (!Number.isInteger(usuarioId) || usuarioId <= 0) {
+    throw new Error('Usuario no autenticado')
+  }
+
+  return usuarioId
+}
+
+export const getTutorialPublicacionContentController = async (
+  _req: Request,
+  res: Response
+) => {
+  try {
+    const result = await getTutorialPublicacionContentService()
+
+    return res.status(200).json({
+      ok: true,
+      data: result
+    })
+  } catch (error) {
+    console.error('Error al obtener contenido del tutorial:', error)
+
+    return res.status(500).json({
+      ok: false,
+      message: 'No se pudo obtener el contenido del tutorial'
+    })
+  }
+}
+
+export const getTutorialPublicacionEstadoController = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const usuarioId = getAuthenticatedUserId(req as AuthenticatedRequest)
+    const result = await getTutorialPublicacionEstadoService({ usuarioId })
+
+    return res.status(200).json({
+      ok: true,
+      data: result
+    })
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Usuario no autenticado') {
+      return res.status(401).json({
+        ok: false,
+        message: 'Usuario no autenticado'
+      })
+    }
+
+    console.error('Error al obtener estado del tutorial:', error)
+
+    return res.status(500).json({
+      ok: false,
+      message: 'No se pudo obtener el estado del tutorial'
+    })
+  }
+}
+
+export const confirmTutorialPublicacionController = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const usuarioId = getAuthenticatedUserId(req as AuthenticatedRequest)
+    const result = await confirmTutorialPublicacionService({ usuarioId })
+
+    return res.status(200).json({
+      ok: true,
+      data: result
+    })
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Usuario no autenticado') {
+      return res.status(401).json({
+        ok: false,
+        message: 'Usuario no autenticado'
+      })
+    }
+
+    console.error('Error al confirmar tutorial:', error)
+
+    return res.status(500).json({
+      ok: false,
+      message: 'No se pudo confirmar el tutorial'
+    })
+  }
+}

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.repository.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.repository.ts
@@ -1,0 +1,63 @@
+import { prisma } from '../../lib/prisma.client.js'
+import type { TutorialPublicacionEstadoRecord } from './tutorial-publicacion.types.js'
+
+const mapTutorialEstadoRecord = (record: {
+  id: number
+  usuarioId: number
+  confirmado: boolean
+  vistoEn: Date | null
+  confirmadoEn: Date | null
+}): TutorialPublicacionEstadoRecord => ({
+  id: record.id,
+  usuarioId: record.usuarioId,
+  confirmado: record.confirmado,
+  vistoEn: record.vistoEn,
+  confirmadoEn: record.confirmadoEn
+})
+
+export const findTutorialEstadoByUsuarioIdRepository = async (
+  usuarioId: number
+): Promise<TutorialPublicacionEstadoRecord | null> => {
+  const record = await prisma.tutorialPublicacionUsuario.findUnique({
+    where: { usuarioId },
+    select: {
+      id: true,
+      usuarioId: true,
+      confirmado: true,
+      vistoEn: true,
+      confirmadoEn: true
+    }
+  })
+
+  return record ? mapTutorialEstadoRecord(record) : null
+}
+
+export const upsertTutorialConfirmadoRepository = async (
+  usuarioId: number
+): Promise<TutorialPublicacionEstadoRecord> => {
+  const now = new Date()
+
+  const record = await prisma.tutorialPublicacionUsuario.upsert({
+    where: { usuarioId },
+    create: {
+      usuarioId,
+      confirmado: true,
+      vistoEn: now,
+      confirmadoEn: now
+    },
+    update: {
+      confirmado: true,
+      vistoEn: now,
+      confirmadoEn: now
+    },
+    select: {
+      id: true,
+      usuarioId: true,
+      confirmado: true,
+      vistoEn: true,
+      confirmadoEn: true
+    }
+  })
+
+  return mapTutorialEstadoRecord(record)
+}

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.routes.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.routes.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express'
+import { requireAuth } from '../../middleware/auth.middleware.js'
+import {
+  confirmTutorialPublicacionController,
+  getTutorialPublicacionContentController,
+  getTutorialPublicacionEstadoController
+} from './tutorial-publicacion.controller.js'
+
+const tutorialPublicacionRoutes = Router()
+
+tutorialPublicacionRoutes.get(
+  '/',
+  requireAuth,
+  getTutorialPublicacionContentController
+)
+
+tutorialPublicacionRoutes.get(
+  '/estado',
+  requireAuth,
+  getTutorialPublicacionEstadoController
+)
+
+tutorialPublicacionRoutes.post(
+  '/confirmar',
+  requireAuth,
+  confirmTutorialPublicacionController
+)
+
+
+export default tutorialPublicacionRoutes

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.service.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.service.ts
@@ -1,0 +1,52 @@
+import { TUTORIAL_PUBLICACION_CONTENT } from './tutorial-publicacion.constants.js'
+import {
+  findTutorialEstadoByUsuarioIdRepository,
+  upsertTutorialConfirmadoRepository
+} from './tutorial-publicacion.repository.js'
+import type {
+  ConfirmTutorialInput,
+  ConfirmTutorialResult,
+  GetTutorialEstadoInput,
+  TutorialPublicacionContent,
+  TutorialPublicacionEstado
+} from './tutorial-publicacion.types.js'
+
+export const getTutorialPublicacionContentService =
+  async (): Promise<TutorialPublicacionContent> => {
+    return TUTORIAL_PUBLICACION_CONTENT
+  }
+
+export const getTutorialPublicacionEstadoService = async ({
+  usuarioId
+}: GetTutorialEstadoInput): Promise<TutorialPublicacionEstado> => {
+  const estado = await findTutorialEstadoByUsuarioIdRepository(usuarioId)
+
+  if (!estado) {
+    return {
+      debeMostrarTutorial: true,
+      confirmado: false,
+      vistoEn: null,
+      confirmadoEn: null
+    }
+  }
+
+  return {
+    debeMostrarTutorial: !estado.confirmado,
+    confirmado: estado.confirmado,
+    vistoEn: estado.vistoEn ? estado.vistoEn.toISOString() : null,
+    confirmadoEn: estado.confirmadoEn ? estado.confirmadoEn.toISOString() : null
+  }
+}
+
+export const confirmTutorialPublicacionService = async ({
+  usuarioId
+}: ConfirmTutorialInput): Promise<ConfirmTutorialResult> => {
+  const estado = await upsertTutorialConfirmadoRepository(usuarioId)
+
+  return {
+    confirmado: estado.confirmado,
+    confirmadoEn: estado.confirmadoEn
+      ? estado.confirmadoEn.toISOString()
+      : new Date().toISOString()
+  }
+}

--- a/backend/src/modules/tutorial-publicacion/tutorial-publicacion.types.ts
+++ b/backend/src/modules/tutorial-publicacion/tutorial-publicacion.types.ts
@@ -1,0 +1,36 @@
+export type TutorialPublicacionContent = {
+  titulo: string
+  mensaje: string
+  videoUrl: string
+  thumbnailUrl: string | null
+  subtitlesUrl: string | null
+  checkboxLabel: string
+}
+
+export type TutorialPublicacionEstado = {
+  debeMostrarTutorial: boolean
+  confirmado: boolean
+  vistoEn: string | null
+  confirmadoEn: string | null
+}
+
+export type TutorialPublicacionEstadoRecord = {
+  id: number
+  usuarioId: number
+  confirmado: boolean
+  vistoEn: Date | null
+  confirmadoEn: Date | null
+}
+
+export type GetTutorialEstadoInput = {
+  usuarioId: number
+}
+
+export type ConfirmTutorialInput = {
+  usuarioId: number
+}
+
+export type ConfirmTutorialResult = {
+  confirmado: boolean
+  confirmadoEn: string
+}


### PR DESCRIPTION
## Resumen
Se agrega la base backend para la HU10 de publicación: tutorial previo a la creación de inmueble.

## Cambios realizados
- Nuevo modelo Prisma `TutorialPublicacionUsuario`
- Relación con `Usuario`
- Estructura base del módulo `tutorial-publicacion`
- Sincronización con `develop`

## Notas
- Schema Prisma validado correctamente
- Backend y frontend levantan sin errores
- La migración sobre la BD compartida no se aplicó por drift detectado