### PR TITLE
feat(logic): reset maestro de estado, filtros y URL T4 -terminado

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -47,6 +47,8 @@ import { UbicacionEspecificaPanel } from '@/components/filters/UbicacionEspecifi
 import ComparatorModal from '@/components/busqueda/ComparatorModal'
 import EtiquetasSidebar from '@/components/filters/EtiquetasSidebar'
 import { useSearchFilters, BusquedaModo } from '@/hooks/useSearchFilters'
+import { useFiltrosActivos } from '@/hooks/useFiltrosActivos'
+import { ActiveFilterTags } from '@/components/filters/ActiveFilterTags'
 
 // Carga dinámica del mapa (sin SSR)
 const MapView = nextDynamic(() => import('./MapView'), {
@@ -154,7 +156,16 @@ function BusquedaMapaContent() {
   const isRecomendadosActive = searchParams.get('orden') === 'recomendados'
   const filterResetKey = searchParams.toString();
 
-  const { getBusquedaModo, cambiarAModoGeneral } = useSearchFilters()
+  const { getBusquedaModo, cambiarAModoGeneral, clearAllFilters } = useSearchFilters()
+  const filtrosActivos = useFiltrosActivos()
+
+  const handleClearAllFilters = () => {
+  clearAllFilters(router, new URLSearchParams(searchParams.toString()))
+  setIsClusterView(false)
+  setClusterProperties([])
+  setActiveClusterIds([])
+  setListPage(1)
+     }
   const busquedaModo: BusquedaModo = getBusquedaModo(
     new URLSearchParams(searchParams.toString())
   )
@@ -1298,6 +1309,16 @@ function BusquedaMapaContent() {
                     </span>
                     <span className="text-gray-500 font-normal">propiedades</span>
                   </span>
+                 
+                     {/* AC 4, 6, 10 — Pills de filtros activos móvil */}
+                      {filtrosActivos.length > 0 && (
+                        <div className="px-4 pt-1">
+                        <ActiveFilterTags
+                         filtros={filtrosActivos}
+                       onClearAll={handleClearAllFilters}
+                            />
+                  </div>
+                           )}
                   {isClusterView && (
                     <button
                       onClick={() => {
@@ -1627,6 +1648,11 @@ function BusquedaMapaContent() {
                                 : 'propiedades encontradas'}
                             </span>
                           </div>
+                          {/* AC 4, 6, 10 — Pills de filtros activos desktop */}
+                        <ActiveFilterTags
+                           filtros={filtrosActivos}
+                            onClearAll={handleClearAllFilters}
+                                 />
                           {isClusterView && (
                             <button
                               type="button"

--- a/frontend/src/components/filters/ActiveFilterTags.tsx
+++ b/frontend/src/components/filters/ActiveFilterTags.tsx
@@ -1,0 +1,52 @@
+'use client'
+// -- BitPro
+// Pills de filtros activos + botón "Limpiar todo"
+
+import { X, SlidersHorizontal } from 'lucide-react'
+import { FiltroActivo } from '@/hooks/useFiltrosActivos'
+
+interface ActiveFilterTagsProps {
+  filtros: FiltroActivo[]
+  onClearAll: () => void
+}
+
+export function ActiveFilterTags({ filtros, onClearAll }: ActiveFilterTagsProps) {
+  // AC 4 & 6 — Si no hay filtros el componente desaparece completamente
+  if (filtros.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5 border-b border-orange-100 bg-orange-50/60">
+
+      {/* Ícono indicador */}
+      <SlidersHorizontal size={12} className="text-orange-400 shrink-0 mr-0.5" />
+
+      {/* AC 4 — Pills individuales con su propio botón X */}
+      {filtros.map((filtro) => (
+        <span
+          key={filtro.id}
+          className="inline-flex items-center gap-1 bg-white border border-orange-200
+                     text-orange-700 text-xs font-medium px-2.5 py-1 rounded-full
+                     shadow-sm transition-all hover:border-orange-300 hover:shadow"
+        >
+          {filtro.label}
+          <button
+            onClick={filtro.onRemove}
+            className="ml-0.5 text-orange-300 hover:text-orange-600 transition-colors rounded-full"
+            aria-label={`Quitar filtro ${filtro.label}`}
+          >
+            <X size={11} strokeWidth={2.5} />
+          </button>
+        </span>
+      ))}
+
+      {/* AC 10 — Botón limpiar todo */}
+      <button
+        onClick={onClearAll}
+        className="ml-auto text-xs text-stone-400 hover:text-red-500
+                   underline underline-offset-2 transition-colors shrink-0"
+      >
+        Limpiar todo
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useSearchFilters.ts
+++ b/frontend/src/hooks/useSearchFilters.ts
@@ -62,6 +62,23 @@ export const useSearchFilters = () => {
     router.push(`/busqueda_mapa?${newParams.toString()}`)
     window.dispatchEvent(new Event('filterUpdate'))
   }
+  // AC 3, 4, 6, 10
+  const clearAllFilters = (
+    router: ReturnType<typeof useRouter>,
+    currentParams: URLSearchParams
+  ) => {
+    sessionStorage.removeItem(FILTER_KEY)
+    sessionStorage.removeItem('propbol_modo_recomendados')
+    sessionStorage.removeItem('propbol_recomendados')
+    const newParams = new URLSearchParams(currentParams.toString())
+    FILTROS_URL_KEYS.forEach((key) => newParams.delete(key))
+    router.push(`/busqueda_mapa?${newParams.toString()}`)
+    window.dispatchEvent(new Event('filterUpdate'))
+  }
+
+  const getActiveFilterCount = (searchParams: URLSearchParams): number => {
+    return FILTROS_URL_KEYS.filter((key) => searchParams.has(key)).length
+  }
 
 
   return {
@@ -69,5 +86,7 @@ export const useSearchFilters = () => {
     getBusquedaModo,
     cambiarAModoGeneral,
     removeFilter,
+    clearAllFilters,      
+    getActiveFilterCount,
   }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el reset completo de filtros y el componente visual 
de etiquetas activas 

## Cambios
- `useSearchFilters.ts` — Añade `clearAllFilters` y `getActiveFilterCount`
- `ActiveFilterTags.tsx` — Componente nuevo de pills con botón X individual 
y botón "Limpiar todo"
- `page.tsx` — Instancia `useFiltrosActivos`, `handleClearAllFilters` y 
renderiza `ActiveFilterTags` en desktop y móvil

## Cómo probar
1. Aplicar varios filtros (precio, ubicación, dormitorios)
2. Verificar que aparecen los pills debajo del header de resultados
3. Hacer click en X de un pill → solo ese filtro desaparece
4. Hacer click en "Limpiar todo" → todos los filtros desaparecen

## Notas
- Si no hay filtros activos el componente no renderiza nada (AC 6)
- Funciona igual en desktop y móvil