### PR TITLE
Gestos táctiles de zoom para mapas móviles

### DIFF
--- a/frontend/src/app/busqueda_mapa/MapView.tsx
+++ b/frontend/src/app/busqueda_mapa/MapView.tsx
@@ -152,6 +152,58 @@ function MapClickHandler({ onMapClick, isDrawingMode }: {
     }
   }, [isDrawingMode, map])
 
+  // Doble toque y arrastre para zoom (one-finger zoom)
+  useEffect(() => {
+    let lastTapTime = 0
+    let isDragging = false
+    let startY = 0
+    let startZoom = 0
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return
+
+      const now = Date.now()
+      const timeSinceLast = now - lastTapTime
+
+      if (timeSinceLast < 350) {
+        // Segundo toque rápido → iniciar modo arrastre
+        isDragging = true
+        startY = e.touches[0].clientY
+        startZoom = map.getZoom()
+        e.preventDefault()
+      }
+
+      lastTapTime = now
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isDragging || e.touches.length !== 1) return
+
+      const currentY = e.touches[0].clientY
+      const deltaY = startY - currentY
+
+      // Cada 50px de movimiento = 1 nivel de zoom
+      const zoomDelta = deltaY / 50
+      map.setZoom(startZoom + zoomDelta, { animate: false })
+      e.preventDefault()
+    }
+
+    const handleTouchEnd = () => {
+      isDragging = false
+    }
+
+    const container = map.getContainer()
+    container.addEventListener('touchstart', handleTouchStart, { passive: false })
+    container.addEventListener('touchmove', handleTouchMove, { passive: false })
+    container.addEventListener('touchend', handleTouchEnd)
+
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart)
+      container.removeEventListener('touchmove', handleTouchMove)
+      container.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [map])
+
   // Doble toque con dos dedos para alejar zoom
   useEffect(() => {
     let lastTwoFingerTapTime = 0

--- a/frontend/src/components/MapaPinSelector.tsx
+++ b/frontend/src/components/MapaPinSelector.tsx
@@ -146,6 +146,43 @@ function EventosMapa({
     }
   }, [map])
 
+  // Doble toque con dos dedos para alejar zoom
+  useEffect(() => {
+    let lastTwoFingerTapTime = 0
+    let maxTouchCount = 0
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length > maxTouchCount) {
+        maxTouchCount = e.touches.length
+      }
+    }
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length !== 0) return
+
+      if (maxTouchCount === 2) {
+        const now = Date.now()
+        const timeSinceLast = now - lastTwoFingerTapTime
+        lastTwoFingerTapTime = now
+
+        if (timeSinceLast < 350) {
+          map.zoomOut(1)
+        }
+      }
+
+      maxTouchCount = 0
+    }
+
+    const container = map.getContainer()
+    container.addEventListener('touchstart', handleTouchStart)
+    container.addEventListener('touchend', handleTouchEnd)
+
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart)
+      container.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [map])
+
   return null
 }
 

--- a/frontend/src/components/MapaPinSelector.tsx
+++ b/frontend/src/components/MapaPinSelector.tsx
@@ -146,6 +146,56 @@ function EventosMapa({
     }
   }, [map])
 
+  // Doble toque y arrastre para zoom continuo (one-finger zoom)
+  useEffect(() => {
+    let lastTapTime = 0
+    let isDragging = false
+    let startY = 0
+    let startZoom = 0
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return
+
+      const now = Date.now()
+      const timeSinceLast = now - lastTapTime
+
+      if (timeSinceLast < 350) {
+        isDragging = true
+        startY = e.touches[0].clientY
+        startZoom = map.getZoom()
+        e.preventDefault()
+      }
+
+      lastTapTime = now
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isDragging || e.touches.length !== 1) return
+
+      const currentY = e.touches[0].clientY
+      const deltaY = startY - currentY
+
+      const zoomDelta = deltaY / 50
+      map.setZoom(startZoom + zoomDelta, { animate: false })
+      e.preventDefault()
+    }
+
+    const handleTouchEnd = () => {
+      isDragging = false
+    }
+
+    const container = map.getContainer()
+    container.addEventListener('touchstart', handleTouchStart, { passive: false })
+    container.addEventListener('touchmove', handleTouchMove, { passive: false })
+    container.addEventListener('touchend', handleTouchEnd)
+
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart)
+      container.removeEventListener('touchmove', handleTouchMove)
+      container.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [map])
+
   // Doble toque con dos dedos para alejar zoom
   useEffect(() => {
     let lastTwoFingerTapTime = 0

--- a/frontend/src/components/MapaPinSelector.tsx
+++ b/frontend/src/components/MapaPinSelector.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { MapContainer as BaseMapContainer, TileLayer, Marker, Polygon, CircleMarker, useMapEvents } from 'react-leaflet'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import L from 'leaflet'
 // Importar CSS y L dinámicamente para evitar errores de SSR
 if (typeof window !== 'undefined') {
@@ -68,7 +68,7 @@ function EventosMapa({
   setVertices,
   setMensajeLimite,
 }: any) {
-  useMapEvents({
+  const map = useMapEvents({
     click(e) {
       if (modoPinActivo) {
         setPinCoords({
@@ -125,6 +125,26 @@ function EventosMapa({
 }
 }
   })
+
+  // Doble toque con un dedo para acercar zoom
+  useEffect(() => {
+    let lastClickTime = 0
+
+    const handleClick = (e: L.LeafletMouseEvent) => {
+      const now = Date.now()
+      const timeSinceLast = now - lastClickTime
+      lastClickTime = now
+
+      if (timeSinceLast < 350) {
+        map.zoomIn(1, { animate: true })
+      }
+    }
+
+    map.on('click', handleClick)
+    return () => {
+      map.off('click', handleClick)
+    }
+  }, [map])
 
   return null
 }

--- a/frontend/src/components/profile/MapaZonas.tsx
+++ b/frontend/src/components/profile/MapaZonas.tsx
@@ -214,6 +214,43 @@ export default function MapaZonas({
             }
         }, [map])
 
+        // Doble toque con dos dedos para alejar zoom
+        useEffect(() => {
+            let lastTwoFingerTapTime = 0
+            let maxTouchCount = 0
+
+            const handleTouchStart = (e: TouchEvent) => {
+                if (e.touches.length > maxTouchCount) {
+                    maxTouchCount = e.touches.length
+                }
+            }
+
+            const handleTouchEnd = (e: TouchEvent) => {
+                if (e.touches.length !== 0) return
+
+                if (maxTouchCount === 2) {
+                    const now = Date.now()
+                    const timeSinceLast = now - lastTwoFingerTapTime
+                    lastTwoFingerTapTime = now
+
+                    if (timeSinceLast < 350) {
+                        map.zoomOut(1)
+                    }
+                }
+
+                maxTouchCount = 0
+            }
+
+            const container = map.getContainer()
+            container.addEventListener('touchstart', handleTouchStart)
+            container.addEventListener('touchend', handleTouchEnd)
+
+            return () => {
+                container.removeEventListener('touchstart', handleTouchStart)
+                container.removeEventListener('touchend', handleTouchEnd)
+            }
+        }, [map])
+
         return null
     }
 

--- a/frontend/src/components/profile/MapaZonas.tsx
+++ b/frontend/src/components/profile/MapaZonas.tsx
@@ -214,6 +214,56 @@ export default function MapaZonas({
             }
         }, [map])
 
+        // Doble toque y arrastre para zoom continuo (one-finger zoom)
+        useEffect(() => {
+            let lastTapTime = 0
+            let isDragging = false
+            let startY = 0
+            let startZoom = 0
+
+            const handleTouchStart = (e: TouchEvent) => {
+                if (e.touches.length !== 1) return
+
+                const now = Date.now()
+                const timeSinceLast = now - lastTapTime
+
+                if (timeSinceLast < 350) {
+                    isDragging = true
+                    startY = e.touches[0].clientY
+                    startZoom = map.getZoom()
+                    e.preventDefault()
+                }
+
+                lastTapTime = now
+            }
+
+            const handleTouchMove = (e: TouchEvent) => {
+                if (!isDragging || e.touches.length !== 1) return
+
+                const currentY = e.touches[0].clientY
+                const deltaY = startY - currentY
+
+                const zoomDelta = deltaY / 50
+                map.setZoom(startZoom + zoomDelta, { animate: false })
+                e.preventDefault()
+            }
+
+            const handleTouchEnd = () => {
+                isDragging = false
+            }
+
+            const container = map.getContainer()
+            container.addEventListener('touchstart', handleTouchStart, { passive: false })
+            container.addEventListener('touchmove', handleTouchMove, { passive: false })
+            container.addEventListener('touchend', handleTouchEnd)
+
+            return () => {
+                container.removeEventListener('touchstart', handleTouchStart)
+                container.removeEventListener('touchmove', handleTouchMove)
+                container.removeEventListener('touchend', handleTouchEnd)
+            }
+        }, [map])
+
         // Doble toque con dos dedos para alejar zoom
         useEffect(() => {
             let lastTwoFingerTapTime = 0

--- a/frontend/src/components/profile/MapaZonas.tsx
+++ b/frontend/src/components/profile/MapaZonas.tsx
@@ -192,6 +192,31 @@ export default function MapaZonas({
         )
     }
 
+    function DobleToque() {
+        const map = useMap()
+
+        useEffect(() => {
+            let lastClickTime = 0
+
+            const handleClick = (e: any) => {
+                const now = Date.now()
+                const timeSinceLast = now - lastClickTime
+                lastClickTime = now
+
+                if (timeSinceLast < 350) {
+                    map.zoomIn(1, { animate: true })
+                }
+            }
+
+            map.on('click', handleClick)
+            return () => {
+                map.off('click', handleClick)
+            }
+        }, [map])
+
+        return null
+    }
+
     function CentrarZona({
         zonas,
         zonaSeleccionadaId,
@@ -255,6 +280,7 @@ export default function MapaZonas({
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
             <CentrarZona zonas={zonas} zonaSeleccionadaId={zonaSeleccionadaId} />
+            <DobleToque />
 
 
             {/* Dibujar TODAS las zonas en el mapa */}


### PR DESCRIPTION
-Doble toque con un dedo para acercar — Dos toques rápidos con un dedo hacen zoom-in en el punto tocado.
-Doble toque con dos dedos para alejar — Dos toques rápidos con dos dedos hacen zoom-out en el mapa.
-Doble toque y arrastre (One-finger zoom) — Tocar dos veces manteniendo el segundo toque presionado y deslizar hacia arriba para zoom-in o hacia abajo para zoom-out.