### PR TITLE
Feature/panel derecho blog

### DIFF
--- a/frontend/src/app/blog/[id]/page.tsx
+++ b/frontend/src/app/blog/[id]/page.tsx
@@ -6,7 +6,7 @@ import BlogCommentsSection from '@/components/blog/BlogCommentsSection'
 import MarkdownRenderer from '@/components/blog/MarkdownRenderer'
 import BlogSharePlaceholder from '@/components/blog/BlogSharePlaceholder'
 import { MOCK_USER_BLOGS } from '@/lib/mock/blogs.mock'
-import { getPublishedBlogById } from '@/services/blogs.service'
+import { getPublishedBlogById, getPublishedBlogs } from '@/services/blogs.service'
 import BackButton from "@/app/blogs/backButton"
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
@@ -57,6 +57,9 @@ export default async function BlogDetailPage({ params }: { params: { id: string 
     userBlog?.resumen ??
     'Este articulo presenta una mirada clara y actual sobre el ecosistema inmobiliario y las oportunidades que aparecen cuando observamos el mercado con criterio.'
   const articleContent = publicBlog?.content?.trim() || userBlog?.resumen?.trim() || summary
+  const recommendedBlogs = (await getPublishedBlogs(8))
+    .filter((blog) => blog.id !== params.id)
+    .slice(0, 4)
 
   return (
     <article className="min-h-screen bg-[linear-gradient(180deg,#fbf6ef_0%,#f8f3eb_38%,#ffffff_100%)] pb-20">
@@ -134,7 +137,7 @@ export default async function BlogDetailPage({ params }: { params: { id: string 
           </div>
 
           <div className="no-capture">
-            <BlogDetailSidebar />
+            <BlogDetailSidebar recommendations={recommendedBlogs} />
           </div>
         </div>
       </main>

--- a/frontend/src/components/blog/BlogDetailSidebar.tsx
+++ b/frontend/src/components/blog/BlogDetailSidebar.tsx
@@ -1,10 +1,60 @@
-export default function BlogDetailSidebar() {
+import Image from 'next/image'
+import Link from 'next/link'
+import type { PublicBlogCard } from '@/types/publicBlog'
+
+type BlogDetailSidebarProps = {
+  recommendations: PublicBlogCard[]
+}
+
+const recommendedImageFallback = '/placeholder-blog.jpg'
+
+const truncateTitle = (title: string) => {
+  const cleanTitle = title.replace(/\s+/g, ' ').trim()
+  return cleanTitle.length > 78 ? `${cleanTitle.slice(0, 78).trimEnd()}...` : cleanTitle
+}
+
+function RecommendedBlogCard({ blog }: { blog: PublicBlogCard }) {
+  return (
+    <Link href={`/blog/${blog.id}`} className="group block">
+      <article className="space-y-3">
+        <div className="relative aspect-[16/9] overflow-hidden rounded-[10px] bg-stone-100">
+          <Image
+            src={blog.imageUrl || recommendedImageFallback}
+            alt={blog.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            sizes="(min-width: 1024px) 320px, 100vw"
+            unoptimized
+          />
+        </div>
+
+        <h3 className="max-w-[16rem] text-sm font-extrabold leading-tight text-stone-900 transition-colors group-hover:text-[#a56400]">
+          {truncateTitle(blog.title)}
+        </h3>
+      </article>
+    </Link>
+  )
+}
+
+export default function BlogDetailSidebar({ recommendations }: BlogDetailSidebarProps) {
   return (
     <aside className="mx-auto w-full max-w-[380px]">
       <div className="min-h-[840px] rounded-[32px] bg-white px-6 py-7 shadow-[0_24px_60px_-48px_rgba(41,37,36,0.5)] sm:min-h-[880px] sm:px-8 sm:py-8">
         <h2 className="text-sm font-bold uppercase tracking-[0.3em] text-[#a56400] sm:text-[0.95rem]">
           Lecturas recomendadas
         </h2>
+
+        {recommendations.length > 0 ? (
+          <div className="mt-7 space-y-8">
+            {recommendations.map((blog) => (
+              <RecommendedBlogCard key={blog.id} blog={blog} />
+            ))}
+          </div>
+        ) : (
+          <p className="mt-7 rounded-[16px] bg-stone-50 px-4 py-5 text-sm font-medium leading-relaxed text-stone-500">
+            No hay lecturas recomendadas por el momento
+          </p>
+        )}
       </div>
     </aside>
   )


### PR DESCRIPTION
Se implementó la sección de `Lecturas recomendadas` en el panel derecho del detalle de blogs. Ahora el panel muestra hasta 4 artículos sugeridos, excluyendo el blog actual, con imagen, título y enlace directo al detalle de cada blog.

También se agregó el estado informativo `No hay lecturas recomendadas por el momento` cuando no existen sugerencias disponibles, manteniendo el diseño responsive y sin modificar backend ni configuraciones del proyecto.