### PR TITLE
Feature/editar multimedia publicacion mejoras  Mejorar edición de multimedia en publicaciones

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -149,8 +149,8 @@ app.use(
   }),
 );
 
-app.use(express.json());
-app.use("/uploads", express.static(path.resolve("uploads")));
+app.use(express.json({ limit: '100mb' }))
+app.use(express.urlencoded({ extended: true, limit: '100mb' }))
 
 // --------------------
 // RUTAS LEGACY

--- a/backend/src/middleware/uploadMultimedia.middleware.ts
+++ b/backend/src/middleware/uploadMultimedia.middleware.ts
@@ -1,0 +1,26 @@
+import multer from 'multer'
+
+const storage = multer.memoryStorage()
+
+const fileFilter = (
+  _req: Express.Request,
+  file: Express.Multer.File,
+  cb: multer.FileFilterCallback
+) => {
+  const formatosPermitidos = ['image/jpeg', 'image/png']
+
+  if (formatosPermitidos.includes(file.mimetype)) {
+    cb(null, true)
+    return
+  }
+
+  cb(new Error('FORMATO_IMAGEN_INVALIDO'))
+}
+
+export const uploadMultimedia = multer({
+  storage,
+  limits: {
+    fileSize: 5 * 1024 * 1024
+  },
+  fileFilter
+})

--- a/backend/src/modules/publicacion/publicacion.controller.ts
+++ b/backend/src/modules/publicacion/publicacion.controller.ts
@@ -456,7 +456,7 @@ export const editarMultimediaPublicacionController = async (
         case 'LIMITE_IMAGENES':
           return res.status(400).json({
             ok: false,
-            message: 'Has alcanzado el límite máximo de 10 imágenes.'
+            message: 'Has alcanzado el límite máximo de 5 imágenes.'
           })
 
         case 'FORMATO_IMAGEN_INVALIDO':

--- a/backend/src/modules/publicacion/publicacion.controller.ts
+++ b/backend/src/modules/publicacion/publicacion.controller.ts
@@ -3,6 +3,7 @@ import {
   eliminarPublicacionService,
   listarMisPublicacionesService,
   editarPublicacionService,
+  editarMultimediaPublicacionService,
   obtenerResumenFinalService,
   obtenerDetallePublicacionService,
   obtenerDetallePublicacionPorInmuebleService,
@@ -281,6 +282,7 @@ export const obtenerDetallePublicacionController = async (req: Request, res: Res
     })
   }
 }
+
 export const obtenerDetallePublicacionPorInmuebleController = async (
   req: Request,
   res: Response
@@ -319,6 +321,7 @@ export const obtenerDetallePublicacionPorInmuebleController = async (
     })
   }
 }
+
 export const confirmarPublicacionController = async (req: AuthRequest, res: Response) => {
   const publicacionId = Number(req.params.id)
   const usuarioSolicitanteId = req.user?.id
@@ -380,6 +383,101 @@ export const confirmarPublicacionController = async (req: AuthRequest, res: Resp
     return res.status(500).json({
       ok: false,
       message: 'No se pudo confirmar la publicación'
+    })
+  }
+}
+
+export const editarMultimediaPublicacionController = async (
+  req: AuthRequest,
+  res: Response
+) => {
+  const publicacionId = Number(req.params.id)
+  const usuarioSolicitanteId = req.user?.id
+  const archivos = (req.files as Express.Multer.File[]) ?? []
+
+  try {
+    const resultado = await editarMultimediaPublicacionService(
+      publicacionId,
+      Number(usuarioSolicitanteId),
+      req.body,
+      archivos
+    )
+
+    return res.status(200).json({
+      ok: true,
+      message: 'Contenido multimedia actualizado correctamente',
+      data: resultado
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      switch (error.message) {
+        case 'ID_INVALIDO':
+          return res.status(400).json({
+            ok: false,
+            message: 'El id de la publicación es inválido'
+          })
+
+        case 'USUARIO_INVALIDO':
+          return res.status(401).json({
+            ok: false,
+            message: 'Usuario no autenticado'
+          })
+
+        case 'PUBLICACION_NO_EXISTE':
+          return res.status(404).json({
+            ok: false,
+            message: 'La publicación no existe'
+          })
+
+        case 'NO_AUTORIZADO':
+          return res.status(403).json({
+            ok: false,
+            message: 'No puede editar multimedia de publicaciones de otros usuarios'
+          })
+
+        case 'PUBLICACION_YA_ELIMINADA':
+          return res.status(409).json({
+            ok: false,
+            message: 'La publicación ya fue eliminada'
+          })
+
+        case 'VIDEO_INVALIDO':
+          return res.status(400).json({
+            ok: false,
+            message: 'Solo se permiten enlaces de YouTube o plataformas permitidas.'
+          })
+
+        case 'MINIMO_UNA_IMAGEN':
+          return res.status(400).json({
+            ok: false,
+            message: 'La publicación debe tener al menos 1 imagen.'
+          })
+
+        case 'LIMITE_IMAGENES':
+          return res.status(400).json({
+            ok: false,
+            message: 'Has alcanzado el límite máximo de 10 imágenes.'
+          })
+
+        case 'FORMATO_IMAGEN_INVALIDO':
+          return res.status(400).json({
+            ok: false,
+            message: 'Formato no válido. Solo se permiten archivos JPG y PNG.'
+          })
+
+        case 'LIMIT_FILE_SIZE':
+          return res.status(400).json({
+            ok: false,
+            message: 'El archivo supera el tamaño máximo permitido de 5MB por imagen.'
+          })
+      }
+    }
+
+    console.error('Error al editar multimedia de publicación:', error)
+
+    return res.status(500).json({
+      ok: false,
+      message: 'No se pudo actualizar el contenido multimedia'
     })
   }
 }

--- a/backend/src/modules/publicacion/publicacion.repository.ts
+++ b/backend/src/modules/publicacion/publicacion.repository.ts
@@ -377,6 +377,7 @@ export const buscarDetallePublicacionPorInmuebleIdRepository = async (inmuebleId
     }
   })
 }
+
 export const confirmarPublicacionRepository = async (publicacionId: number) => {
   return prisma.publicacion.update({
     where: { id: publicacionId },
@@ -390,6 +391,63 @@ export const confirmarPublicacionRepository = async (publicacionId: number) => {
           ubicacion: true
         }
       }
+    }
+  })
+}
+
+type NuevaMultimediaInput = {
+  url: string
+  tipo: 'IMAGEN' | 'VIDEO'
+  pesoMb?: number | null
+  publicacionId: number
+}
+
+export const eliminarMultimediaPorIdsRepository = async (
+  publicacionId: number,
+  multimediaIds: number[]
+) => {
+  if (multimediaIds.length === 0) return { count: 0 }
+
+  return prisma.multimedia.deleteMany({
+    where: {
+      id: {
+        in: multimediaIds
+      },
+      publicacionId
+    }
+  })
+}
+
+export const eliminarVideosDePublicacionRepository = async (
+  publicacionId: number
+) => {
+  return prisma.multimedia.deleteMany({
+    where: {
+      publicacionId,
+      tipo: 'VIDEO'
+    }
+  })
+}
+
+export const crearMultimediaRepository = async (
+  data: NuevaMultimediaInput[]
+) => {
+  if (data.length === 0) return { count: 0 }
+
+  return prisma.multimedia.createMany({
+    data
+  })
+}
+
+export const buscarMultimediaPublicacionRepository = async (
+  publicacionId: number
+) => {
+  return prisma.multimedia.findMany({
+    where: {
+      publicacionId
+    },
+    orderBy: {
+      id: 'asc'
     }
   })
 }

--- a/backend/src/modules/publicacion/publicacion.routes.ts
+++ b/backend/src/modules/publicacion/publicacion.routes.ts
@@ -23,7 +23,7 @@ router.patch('/:id/confirmar', requireAuth, confirmarPublicacionController)
 router.put(
   '/:id/multimedia',
   requireAuth,
-  uploadMultimedia.array('imagenesNuevas', 10),
+  uploadMultimedia.array('imagenesNuevas', 5),
   editarMultimediaPublicacionController
 )
 

--- a/backend/src/modules/publicacion/publicacion.routes.ts
+++ b/backend/src/modules/publicacion/publicacion.routes.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express'
 import { requireAuth } from '../../middleware/auth.middleware.js'
+import { uploadMultimedia } from '../../middleware/uploadMultimedia.middleware.js'
 import {
   listarMisPublicacionesController,
   obtenerResumenFinalController,
   editarPublicacionController,
+  editarMultimediaPublicacionController,
   eliminarPublicacionController,
   obtenerDetallePublicacionController,
   obtenerDetallePublicacionPorInmuebleController,
@@ -17,6 +19,14 @@ router.get('/:id/resumen-final', requireAuth, obtenerResumenFinalController)
 router.get('/inmueble/:inmuebleId/detalle', obtenerDetallePublicacionPorInmuebleController)
 router.get('/:id/detalle', obtenerDetallePublicacionController)
 router.patch('/:id/confirmar', requireAuth, confirmarPublicacionController)
+
+router.put(
+  '/:id/multimedia',
+  requireAuth,
+  uploadMultimedia.array('imagenesNuevas', 10),
+  editarMultimediaPublicacionController
+)
+
 router.put('/:id', requireAuth, editarPublicacionController)
 router.delete('/:id', requireAuth, eliminarPublicacionController)
 

--- a/backend/src/modules/publicacion/publicacion.service.ts
+++ b/backend/src/modules/publicacion/publicacion.service.ts
@@ -599,7 +599,11 @@ const subirImagenACloudinary = async (
 export const editarMultimediaPublicacionService = async (
   publicacionId: number,
   usuarioSolicitanteId: number,
-  data: EditarMultimediaInput,
+  data: EditarMultimediaInput & {
+    imagenesActuales?: unknown
+    imagenesNuevas?: unknown
+    videoUrls?: unknown
+  },
   archivos: Express.Multer.File[]
 ) => {
   if (Number.isNaN(publicacionId) || publicacionId <= 0) {
@@ -624,31 +628,87 @@ export const editarMultimediaPublicacionService = async (
     throw new Error('PUBLICACION_YA_ELIMINADA')
   }
 
-  const imagenesAEliminar = parseImagenesAEliminar(data.imagenesAEliminar)
-  const videoUrl = normalizarTexto(data.videoUrl)
+  const parseStringArray = (valor: unknown): string[] => {
+    if (!valor) return []
 
-  if (!esVideoPermitido(videoUrl)) {
+    if (Array.isArray(valor)) {
+      return valor.map((item) => String(item).trim()).filter(Boolean)
+    }
+
+    if (typeof valor === 'string') {
+      try {
+        const parsed = JSON.parse(valor)
+
+        if (Array.isArray(parsed)) {
+          return parsed.map((item) => String(item).trim()).filter(Boolean)
+        }
+      } catch {
+        return valor.trim() ? [valor.trim()] : []
+      }
+    }
+
+    return []
+  }
+
+  const subirBase64ACloudinary = async (base64: string) => {
+    const resultado = await cloudinary.uploader.upload(base64, {
+      folder: 'propbol/publicaciones',
+      resource_type: 'image'
+    })
+
+    return resultado.secure_url
+  }
+
+  const imagenesActualesUrls = parseStringArray(data.imagenesActuales)
+  const imagenesNuevasBase64 = parseStringArray(data.imagenesNuevas)
+  const videosUrls = parseStringArray(data.videoUrls)
+
+  const videoUrlLegacy = normalizarTexto(data.videoUrl)
+
+  const videosFinales =
+    videosUrls.length > 0
+      ? videosUrls.slice(0, 2)
+      : videoUrlLegacy
+        ? [videoUrlLegacy]
+        : []
+
+  const videosValidos = videosFinales.every((video) => esVideoPermitido(video))
+
+  if (!videosValidos) {
     throw new Error('VIDEO_INVALIDO')
   }
 
-  const imagenesActuales = publicacion.multimedia.filter(
+  const imagenesActualesDb = publicacion.multimedia.filter(
     (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN
   )
 
+  const imagenesAEliminarPorUrl = imagenesActualesDb
+    .filter((item) => !imagenesActualesUrls.includes(item.url))
+    .map((item) => item.id)
+
+  const imagenesAEliminarPorId = parseImagenesAEliminar(data.imagenesAEliminar)
+
+  const imagenesAEliminar = Array.from(
+    new Set([...imagenesAEliminarPorUrl, ...imagenesAEliminarPorId])
+  )
+
   const totalImagenesDespues =
-    imagenesActuales.length - imagenesAEliminar.length + archivos.length
+    imagenesActualesDb.length -
+    imagenesAEliminar.length +
+    archivos.length +
+    imagenesNuevasBase64.length
 
   if (totalImagenesDespues <= 0) {
     throw new Error('MINIMO_UNA_IMAGEN')
   }
 
-  if (totalImagenesDespues > 10) {
+  if (totalImagenesDespues > 5) {
     throw new Error('LIMITE_IMAGENES')
   }
 
   await eliminarMultimediaPorIdsRepository(publicacionId, imagenesAEliminar)
 
-  const nuevasImagenes = await Promise.all(
+  const nuevasImagenesDesdeArchivos = await Promise.all(
     archivos.map(async (file) => {
       const url = await subirImagenACloudinary(file)
 
@@ -661,19 +721,35 @@ export const editarMultimediaPublicacionService = async (
     })
   )
 
-  await crearMultimediaRepository(nuevasImagenes)
+  const nuevasImagenesDesdeBase64 = await Promise.all(
+    imagenesNuevasBase64.map(async (base64) => {
+      const url = await subirBase64ACloudinary(base64)
 
-  await eliminarVideosDePublicacionRepository(publicacionId)
-
-  if (videoUrl) {
-    await crearMultimediaRepository([
-      {
-        url: videoUrl,
-        tipo: 'VIDEO',
+      return {
+        url,
+        tipo: 'IMAGEN' as const,
         pesoMb: null,
         publicacionId
       }
-    ])
+    })
+  )
+
+  await crearMultimediaRepository([
+    ...nuevasImagenesDesdeArchivos,
+    ...nuevasImagenesDesdeBase64
+  ])
+
+  await eliminarVideosDePublicacionRepository(publicacionId)
+
+  if (videosFinales.length > 0) {
+    await crearMultimediaRepository(
+      videosFinales.map((video) => ({
+        url: video,
+        tipo: 'VIDEO' as const,
+        pesoMb: null,
+        publicacionId
+      }))
+    )
   }
 
   const multimediaActualizada =
@@ -695,6 +771,7 @@ export const editarMultimediaPublicacionService = async (
       tipo: item.tipo,
       pesoMb: item.pesoMb ? Number(item.pesoMb) : null
     })),
-    videoUrl: videos[0]?.url ?? null
+    videoUrl: videos[0]?.url ?? null,
+    videoUrls: videos.map((item) => item.url)
   }
 }

--- a/backend/src/modules/publicacion/publicacion.service.ts
+++ b/backend/src/modules/publicacion/publicacion.service.ts
@@ -6,8 +6,13 @@ import {
   eliminarLogicamentePublicacionRepository,
   buscarDetallePublicacionPorIdRepository,
   confirmarPublicacionRepository,
-  buscarDetallePublicacionPorInmuebleIdRepository
+  buscarDetallePublicacionPorInmuebleIdRepository,
+  eliminarMultimediaPorIdsRepository,
+  eliminarVideosDePublicacionRepository,
+  crearMultimediaRepository,
+  buscarMultimediaPublicacionRepository
 } from './publicacion.repository.js'
+import { cloudinary } from '../../config/cloudinary.js'
 
 type TipoAccionPermitido = 'VENTA' | 'ALQUILER' | 'ANTICRETO'
 
@@ -387,12 +392,18 @@ export const obtenerDetallePublicacionService = async (publicacionId: number) =>
     ubicacionTexto: publicacion.inmueble.ubicacion?.direccion || 'Ubicación no disponible',
     descripcion:
       publicacion.descripcion || publicacion.inmueble.descripcion || 'Sin descripción disponible',
-    imagenes: publicacion.multimedia.map((item) => ({
-      id: item.id,
-      url: item.url,
-      tipo: item.tipo,
-      pesoMb: item.pesoMb ? Number(item.pesoMb) : null
-    })),
+    imagenes: publicacion.multimedia
+      .filter((item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN)
+      .map((item) => ({
+        id: item.id,
+        url: item.url,
+        tipo: item.tipo,
+        pesoMb: item.pesoMb ? Number(item.pesoMb) : null
+      })),
+    videoUrl:
+      publicacion.multimedia.find(
+        (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_VIDEO
+      )?.url ?? null,
     detalles: {
       habitaciones: publicacion.inmueble.nroCuartos ?? null,
       banos: publicacion.inmueble.nroBanos ?? null,
@@ -445,12 +456,18 @@ export const obtenerDetallePublicacionPorInmuebleService = async (inmuebleId: nu
     ubicacionTexto: publicacion.inmueble.ubicacion?.direccion || 'Ubicación no disponible',
     descripcion:
       publicacion.descripcion || publicacion.inmueble.descripcion || 'Sin descripción disponible',
-    imagenes: publicacion.multimedia.map((item) => ({
-      id: item.id,
-      url: item.url,
-      tipo: item.tipo,
-      pesoMb: item.pesoMb ? Number(item.pesoMb) : null
-    })),
+    imagenes: publicacion.multimedia
+      .filter((item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN)
+      .map((item) => ({
+        id: item.id,
+        url: item.url,
+        tipo: item.tipo,
+        pesoMb: item.pesoMb ? Number(item.pesoMb) : null
+      })),
+    videoUrl:
+      publicacion.multimedia.find(
+        (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_VIDEO
+      )?.url ?? null,
     detalles: {
       habitaciones: publicacion.inmueble.nroCuartos ?? null,
       banos: publicacion.inmueble.nroBanos ?? null,
@@ -478,6 +495,7 @@ export const obtenerDetallePublicacionPorInmuebleService = async (inmuebleId: nu
     }
   }
 }
+
 export const confirmarPublicacionService = async (
   publicacionId: number,
   usuarioSolicitanteId: number
@@ -515,5 +533,166 @@ export const confirmarPublicacionService = async (
     estado: publicacionConfirmada.estado,
     fechaPublicacion: publicacionConfirmada.fechaPublicacion,
     multimediaTotal: publicacionConfirmada.multimedia.length
+  }
+}
+
+type EditarMultimediaInput = {
+  imagenesAEliminar?: unknown
+  videoUrl?: unknown
+}
+
+const esVideoPermitido = (url: string) => {
+  const valor = url.trim()
+
+  if (!valor) return true
+
+  return (
+    valor.includes('youtube.com') ||
+    valor.includes('youtu.be') ||
+    valor.includes('vimeo.com')
+  )
+}
+
+const parseImagenesAEliminar = (valor: unknown): number[] => {
+  if (!valor) return []
+
+  if (Array.isArray(valor)) {
+    return valor
+      .map((item) => Number(item))
+      .filter((item) => !Number.isNaN(item) && item > 0)
+  }
+
+  if (typeof valor === 'string') {
+    try {
+      const parsed = JSON.parse(valor)
+
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => Number(item))
+          .filter((item) => !Number.isNaN(item) && item > 0)
+      }
+    } catch {
+      const numero = Number(valor)
+      return !Number.isNaN(numero) && numero > 0 ? [numero] : []
+    }
+  }
+
+  return []
+}
+
+const subirImagenACloudinary = async (
+  file: Express.Multer.File
+): Promise<string> => {
+  const base64 = file.buffer.toString('base64')
+  const dataUri = `data:${file.mimetype};base64,${base64}`
+
+  const resultado = await cloudinary.uploader.upload(dataUri, {
+    folder: 'propbol/publicaciones',
+    resource_type: 'image'
+  })
+
+  return resultado.secure_url
+}
+
+export const editarMultimediaPublicacionService = async (
+  publicacionId: number,
+  usuarioSolicitanteId: number,
+  data: EditarMultimediaInput,
+  archivos: Express.Multer.File[]
+) => {
+  if (Number.isNaN(publicacionId) || publicacionId <= 0) {
+    throw new Error('ID_INVALIDO')
+  }
+
+  if (Number.isNaN(usuarioSolicitanteId) || usuarioSolicitanteId <= 0) {
+    throw new Error('USUARIO_INVALIDO')
+  }
+
+  const publicacion = await buscarPublicacionPorIdRepository(publicacionId)
+
+  if (!publicacion) {
+    throw new Error('PUBLICACION_NO_EXISTE')
+  }
+
+  if (publicacion.usuarioId !== usuarioSolicitanteId) {
+    throw new Error('NO_AUTORIZADO')
+  }
+
+  if (publicacion.estado === ESTADO_PUBLICACION_ELIMINADA) {
+    throw new Error('PUBLICACION_YA_ELIMINADA')
+  }
+
+  const imagenesAEliminar = parseImagenesAEliminar(data.imagenesAEliminar)
+  const videoUrl = normalizarTexto(data.videoUrl)
+
+  if (!esVideoPermitido(videoUrl)) {
+    throw new Error('VIDEO_INVALIDO')
+  }
+
+  const imagenesActuales = publicacion.multimedia.filter(
+    (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN
+  )
+
+  const totalImagenesDespues =
+    imagenesActuales.length - imagenesAEliminar.length + archivos.length
+
+  if (totalImagenesDespues <= 0) {
+    throw new Error('MINIMO_UNA_IMAGEN')
+  }
+
+  if (totalImagenesDespues > 10) {
+    throw new Error('LIMITE_IMAGENES')
+  }
+
+  await eliminarMultimediaPorIdsRepository(publicacionId, imagenesAEliminar)
+
+  const nuevasImagenes = await Promise.all(
+    archivos.map(async (file) => {
+      const url = await subirImagenACloudinary(file)
+
+      return {
+        url,
+        tipo: 'IMAGEN' as const,
+        pesoMb: Number((file.size / 1024 / 1024).toFixed(2)),
+        publicacionId
+      }
+    })
+  )
+
+  await crearMultimediaRepository(nuevasImagenes)
+
+  await eliminarVideosDePublicacionRepository(publicacionId)
+
+  if (videoUrl) {
+    await crearMultimediaRepository([
+      {
+        url: videoUrl,
+        tipo: 'VIDEO',
+        pesoMb: null,
+        publicacionId
+      }
+    ])
+  }
+
+  const multimediaActualizada =
+    await buscarMultimediaPublicacionRepository(publicacionId)
+
+  const imagenes = multimediaActualizada.filter(
+    (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN
+  )
+
+  const videos = multimediaActualizada.filter(
+    (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_VIDEO
+  )
+
+  return {
+    id: publicacionId,
+    imagenes: imagenes.map((item) => ({
+      id: item.id,
+      url: item.url,
+      tipo: item.tipo,
+      pesoMb: item.pesoMb ? Number(item.pesoMb) : null
+    })),
+    videoUrl: videos[0]?.url ?? null
   }
 }

--- a/backend/src/modules/publicacion/publicacion.service.ts
+++ b/backend/src/modules/publicacion/publicacion.service.ts
@@ -662,7 +662,6 @@ export const editarMultimediaPublicacionService = async (
   const imagenesActualesUrls = parseStringArray(data.imagenesActuales)
   const imagenesNuevasBase64 = parseStringArray(data.imagenesNuevas)
   const videosUrls = parseStringArray(data.videoUrls)
-
   const videoUrlLegacy = normalizarTexto(data.videoUrl)
 
   const videosFinales =
@@ -671,12 +670,6 @@ export const editarMultimediaPublicacionService = async (
       : videoUrlLegacy
         ? [videoUrlLegacy]
         : []
-
-  const videosValidos = videosFinales.every((video) => esVideoPermitido(video))
-
-  if (!videosValidos) {
-    throw new Error('VIDEO_INVALIDO')
-  }
 
   const imagenesActualesDb = publicacion.multimedia.filter(
     (item) => normalizarTipoMultimedia(item.tipo) === TIPO_MULTIMEDIA_IMAGEN
@@ -739,17 +732,21 @@ export const editarMultimediaPublicacionService = async (
     ...nuevasImagenesDesdeBase64
   ])
 
-  await eliminarVideosDePublicacionRepository(publicacionId)
+  const videosValidos = videosFinales.every((video) => esVideoPermitido(video))
 
-  if (videosFinales.length > 0) {
-    await crearMultimediaRepository(
-      videosFinales.map((video) => ({
-        url: video,
-        tipo: 'VIDEO' as const,
-        pesoMb: null,
-        publicacionId
-      }))
-    )
+  if (videosValidos) {
+    await eliminarVideosDePublicacionRepository(publicacionId)
+
+    if (videosFinales.length > 0) {
+      await crearMultimediaRepository(
+        videosFinales.map((video) => ({
+          url: video,
+          tipo: 'VIDEO' as const,
+          pesoMb: null,
+          publicacionId
+        }))
+      )
+    }
   }
 
   const multimediaActualizada =
@@ -772,6 +769,7 @@ export const editarMultimediaPublicacionService = async (
       pesoMb: item.pesoMb ? Number(item.pesoMb) : null
     })),
     videoUrl: videos[0]?.url ?? null,
-    videoUrls: videos.map((item) => item.url)
+    videoUrls: videos.map((item) => item.url),
+    videoError: videosValidos ? null : 'VIDEO_INVALIDO'
   }
 }

--- a/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
+++ b/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
@@ -2,11 +2,15 @@
 
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
+import EditarMultimediaModal from '@/components/publicacion/EditarMultimediaModal'
 import {
   editarPublicacion,
   obtenerDetallePublicacion
 } from '@/services/publicacion.service'
-import type { EditarPublicacionPayload } from '@/types/publicacion'
+import type {
+  EditarPublicacionPayload,
+  PublicacionDetalle
+} from '@/types/publicacion'
 
 type FormState = {
   titulo: string
@@ -66,6 +70,10 @@ export default function EditarPublicacionPage() {
     ubicacion: ''
   })
 
+  const [detallePublicacion, setDetallePublicacion] =
+    useState<PublicacionDetalle | null>(null)
+
+  const [mostrarModalMultimedia, setMostrarModalMultimedia] = useState(false)
   const [originalForm, setOriginalForm] = useState<FormState | null>(null)
   const [fieldErrors, setFieldErrors] = useState<FormErrors>({})
   const [loading, setLoading] = useState(true)
@@ -89,6 +97,7 @@ export default function EditarPublicacionPage() {
           ubicacion: detalle.ubicacionTexto ?? ''
         }
 
+        setDetallePublicacion(detalle)
         setForm(formCargado)
         setOriginalForm(formCargado)
       } catch (err) {
@@ -332,9 +341,19 @@ export default function EditarPublicacionPage() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
-      <h1 className="mb-6 text-3xl font-bold text-black">
-        Editar publicación
-      </h1>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-3xl font-bold text-black">
+          Editar publicación
+        </h1>
+
+        <button
+          type="button"
+          onClick={() => setMostrarModalMultimedia(true)}
+          className="rounded-lg border border-[#D97706] bg-white px-4 py-2 text-sm font-semibold text-[#D97706] transition hover:bg-orange-50"
+        >
+          Editar imágenes y video
+        </button>
+      </div>
 
       {error && (
         <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
@@ -486,6 +505,15 @@ export default function EditarPublicacionPage() {
           </button>
         </div>
       </form>
+
+      {detallePublicacion && (
+        <EditarMultimediaModal
+          open={mostrarModalMultimedia}
+          imagenesActuales={detallePublicacion.imagenes ?? []}
+          videoActual={detallePublicacion.videoUrl}
+          onClose={() => setMostrarModalMultimedia(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
+++ b/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
@@ -506,20 +506,27 @@ export default function EditarPublicacionPage() {
         </div>
       </form>
 
-    {detallePublicacion && (
-  <EditarMultimediaModal
-    open={mostrarModalMultimedia}
-    publicacionId={publicacionId}
-    imagenesActuales={detallePublicacion.imagenes ?? []}
-    videoActual={detallePublicacion.videoUrl}
-    onClose={() => setMostrarModalMultimedia(false)}
-    onSaved={async () => {
-      const detalleActualizado = await obtenerDetallePublicacion(publicacionId)
-      setDetallePublicacion(detalleActualizado)
-      router.refresh()
-    }}
-  />
-)} 
- </div>
+          {detallePublicacion && (
+        <EditarMultimediaModal
+          open={mostrarModalMultimedia}
+          publicacionId={publicacionId}
+          imagenesActuales={
+            detallePublicacion.imagenes?.map((imagen) =>
+              typeof imagen === 'string' ? imagen : imagen.url
+            ) ?? []
+          }
+          videoActual={detallePublicacion.videoUrl}
+          onClose={() => setMostrarModalMultimedia(false)}
+          onSaved={async () => {
+            const detalleActualizado =
+              await obtenerDetallePublicacion(publicacionId)
+
+            setDetallePublicacion(detalleActualizado)
+            setMostrarModalMultimedia(false)
+            router.refresh()
+          }}
+        />
+      )}
+    </div>
   )
 }

--- a/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
+++ b/frontend/src/app/mis-publicaciones/[id]/editar/page.tsx
@@ -506,14 +506,20 @@ export default function EditarPublicacionPage() {
         </div>
       </form>
 
-      {detallePublicacion && (
-        <EditarMultimediaModal
-          open={mostrarModalMultimedia}
-          imagenesActuales={detallePublicacion.imagenes ?? []}
-          videoActual={detallePublicacion.videoUrl}
-          onClose={() => setMostrarModalMultimedia(false)}
-        />
-      )}
-    </div>
+    {detallePublicacion && (
+  <EditarMultimediaModal
+    open={mostrarModalMultimedia}
+    publicacionId={publicacionId}
+    imagenesActuales={detallePublicacion.imagenes ?? []}
+    videoActual={detallePublicacion.videoUrl}
+    onClose={() => setMostrarModalMultimedia(false)}
+    onSaved={async () => {
+      const detalleActualizado = await obtenerDetallePublicacion(publicacionId)
+      setDetallePublicacion(detalleActualizado)
+      router.refresh()
+    }}
+  />
+)} 
+ </div>
   )
 }

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -161,10 +161,10 @@ export default function EditarMultimediaModal({
       setError('')
 
       const apiUrl = getApiUrl()
-      const token = getToken()
+const token = getToken()
 
-      const response = await fetch(
-        `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
+const response = await fetch(
+  `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
         {
           method: 'PUT',
           headers: {

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -451,6 +451,8 @@ export default function EditarMultimediaModal({
             </button>
           </div>
         </div>
+       
+        
       </div>
     </div>
   )

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -1,119 +1,366 @@
 'use client'
 
-import type { PublicacionImagen } from '@/types/publicacion'
+import { useEffect, useRef, useState } from 'react'
 
 type EditarMultimediaModalProps = {
   open: boolean
-  imagenesActuales: PublicacionImagen[]
+  publicacionId: number
+  imagenesActuales: string[]
   videoActual?: string | null
   onClose: () => void
+  onSaved: () => void | Promise<void>
+}
+
+const getApiUrl = () => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+  if (!apiUrl) {
+    throw new Error('Falta NEXT_PUBLIC_API_URL en el archivo .env.local')
+  }
+
+  return apiUrl
+}
+
+const getToken = () => {
+  if (typeof window === 'undefined') return ''
+
+  return (
+    localStorage.getItem('token') ??
+    sessionStorage.getItem('token') ??
+    localStorage.getItem('jwt') ??
+    sessionStorage.getItem('jwt') ??
+    ''
+  )
+}
+
+const convertirArchivoABase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = () => {
+      resolve(String(reader.result))
+    }
+
+    reader.onerror = () => {
+      reject(new Error('No se pudo leer la imagen'))
+    }
+
+    reader.readAsDataURL(file)
+  })
+}
+
+const leerRespuesta = async (response: Response) => {
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (contentType.includes('application/json')) {
+    return response.json()
+  }
+
+  const texto = await response.text()
+
+  throw new Error(
+    texto.includes('<!DOCTYPE')
+      ? `La ruta respondió HTML. Verifica que exista el endpoint. Status: ${response.status}`
+      : texto || `Error HTTP ${response.status}`
+  )
 }
 
 export default function EditarMultimediaModal({
   open,
+  publicacionId,
   imagenesActuales,
   videoActual,
-  onClose
+  onClose,
+  onSaved
 }: EditarMultimediaModalProps) {
+  const inputFileRef = useRef<HTMLInputElement | null>(null)
+
+  const [imagenes, setImagenes] = useState<string[]>([])
+  const [videoUrl, setVideoUrl] = useState('')
+  const [imagenesNuevas, setImagenesNuevas] = useState<string[]>([])
+  const [guardando, setGuardando] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      setImagenes(imagenesActuales ?? [])
+      setVideoUrl(videoActual ?? '')
+      setImagenesNuevas([])
+      setError('')
+    }
+  }, [open, imagenesActuales, videoActual])
+
   if (!open) return null
 
+  const handleAgregarImagen = () => {
+    inputFileRef.current?.click()
+  }
+
+  const handleSeleccionarImagen = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0]
+
+    if (!file) return
+
+    setError('')
+
+    const formatosPermitidos = ['image/jpeg', 'image/png', 'image/jpg']
+
+    if (!formatosPermitidos.includes(file.type)) {
+      setError('Solo se permiten imágenes JPG o PNG')
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      setError('La imagen no puede superar los 5MB')
+      return
+    }
+
+    if (imagenes.length + imagenesNuevas.length >= 10) {
+      setError('Solo puedes tener hasta 10 imágenes')
+      return
+    }
+
+    try {
+      const base64 = await convertirArchivoABase64(file)
+      setImagenesNuevas((prev) => [...prev, base64])
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo cargar la imagen'
+      )
+    } finally {
+      event.target.value = ''
+    }
+  }
+
+  const handleEliminarImagenActual = (index: number) => {
+    setImagenes((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleEliminarImagenNueva = (index: number) => {
+    setImagenesNuevas((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleVistaPrevia = () => {
+    if (!videoUrl.trim()) {
+      setError('Primero ingresa un enlace de video')
+      return
+    }
+
+    window.open(videoUrl.trim(), '_blank', 'noopener,noreferrer')
+  }
+
+  const handleEliminarVideo = () => {
+    setVideoUrl('')
+  }
+
+  const handleGuardar = async () => {
+    try {
+      setGuardando(true)
+      setError('')
+
+      const apiUrl = getApiUrl()
+      const token = getToken()
+
+      const response = await fetch(
+        `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {})
+          },
+          body: JSON.stringify({
+            imagenesActuales: imagenes,
+            imagenesNuevas,
+            videoUrl: videoUrl.trim() || null
+          })
+        }
+      )
+
+      const data = await leerRespuesta(response)
+
+      if (!response.ok) {
+        throw new Error(
+          data?.message ?? data?.error ?? 'No se pudo guardar la multimedia'
+        )
+      }
+
+      await onSaved()
+      onClose()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo guardar la multimedia'
+      )
+    } finally {
+      setGuardando(false)
+    }
+  }
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
-      <div className="w-full max-w-3xl rounded-2xl bg-white p-6 shadow-2xl">
-        <div className="mb-5 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-black">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+      <div className="max-h-[90vh] w-full max-w-5xl overflow-y-auto rounded-2xl bg-white p-7 shadow-xl">
+        <div className="mb-7 flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-black">
             Editar imágenes y video
           </h2>
 
           <button
             type="button"
             onClick={onClose}
-            className="text-2xl text-gray-500 hover:text-black"
+            className="text-3xl leading-none text-gray-500 hover:text-gray-800"
           >
             ×
           </button>
         </div>
 
-        <h3 className="mb-3 text-sm font-semibold text-gray-800">
-          Imágenes actuales ({imagenesActuales.length}/10)
-        </h3>
+        {error && (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-5 py-4 text-red-700">
+            {error}
+          </div>
+        )}
 
-        <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4 md:grid-cols-5">
-          {imagenesActuales.map((imagen) => (
-            <div
-              key={imagen.id}
-              className="relative h-28 overflow-hidden rounded-xl border border-gray-200"
-            >
-              <img
-                src={imagen.url}
-                alt="Imagen de publicación"
-                className="h-full w-full object-cover"
-              />
+        <div className="mb-8">
+          <h3 className="mb-4 text-lg font-semibold text-gray-800">
+            Imágenes actuales ({imagenes.length + imagenesNuevas.length}/10)
+          </h3>
 
+          <div className="flex flex-wrap gap-4">
+            {imagenes.map((imagen, index) => (
+              <div
+                key={`actual-${imagen}-${index}`}
+                className="relative h-36 w-44 overflow-hidden rounded-xl border border-orange-200 bg-gray-100"
+              >
+                <img
+                  src={imagen}
+                  alt={`Imagen actual ${index + 1}`}
+                  className="h-full w-full object-cover"
+                />
+
+                <button
+                  type="button"
+                  onClick={() => handleEliminarImagenActual(index)}
+                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+
+            {imagenesNuevas.map((imagen, index) => (
+              <div
+                key={`nueva-${index}`}
+                className="relative h-36 w-44 overflow-hidden rounded-xl border border-orange-200 bg-gray-100"
+              >
+                <img
+                  src={imagen}
+                  alt={`Imagen nueva ${index + 1}`}
+                  className="h-full w-full object-cover"
+                />
+
+                <button
+                  type="button"
+                  onClick={() => handleEliminarImagenNueva(index)}
+                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+
+            {imagenes.length + imagenesNuevas.length < 10 && (
               <button
                 type="button"
-                className="absolute right-1 top-1 rounded-full bg-black/50 px-2 py-1 text-xs text-white"
+                onClick={handleAgregarImagen}
+                className="flex h-36 w-44 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 bg-white text-gray-700 hover:bg-gray-50"
               >
-                ×
+                <span className="text-3xl font-bold">+</span>
+                <span className="mt-3 text-lg">Agregar imagen</span>
               </button>
-            </div>
-          ))}
+            )}
+          </div>
 
-          <button
-            type="button"
-            className="flex h-28 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 text-sm text-gray-700 hover:bg-gray-50"
-          >
-            <span className="text-2xl font-bold">+</span>
-            Agregar imagen
-          </button>
+          <input
+            ref={inputFileRef}
+            type="file"
+            accept="image/png,image/jpeg,image/jpg"
+            onChange={handleSeleccionarImagen}
+            className="hidden"
+          />
+
+          <p className="mt-4 text-sm text-gray-500">
+            Puedes subir hasta 10 imágenes. Formatos: JPG, PNG. Tamaño máximo:
+            5MB por imagen.
+          </p>
         </div>
 
-        <p className="mb-6 text-xs text-gray-500">
-          Puedes subir hasta 10 imágenes. Formatos: JPG, PNG. Tamaño máximo:
-          5MB por imagen.
-        </p>
-
-        <div className="mb-6">
-          <label className="mb-2 block text-sm font-semibold text-gray-800">
+        <div className="mb-8">
+          <h3 className="mb-3 text-lg font-semibold text-gray-800">
             Video de la propiedad opcional
-          </label>
+          </h3>
 
-          <div className="flex flex-col gap-3 sm:flex-row">
+          <div className="flex flex-col gap-4 md:flex-row">
             <input
-              type="text"
-              defaultValue={videoActual ?? ''}
-              placeholder="Pega un enlace de YouTube o Vimeo"
-              className="h-11 flex-1 rounded-lg border border-gray-300 px-4 outline-none focus:border-[#D97706]"
+              type="url"
+              value={videoUrl}
+              onChange={(e) => setVideoUrl(e.target.value)}
+              placeholder="https://www.youtube.com/watch?v=..."
+              className="h-14 flex-1 rounded-lg border border-gray-300 px-4 text-lg outline-none focus:border-[#D97706]"
             />
 
             <button
               type="button"
-              className="h-11 rounded-lg border border-[#D97706] px-4 text-sm font-semibold text-[#D97706] hover:bg-orange-50"
+              onClick={handleVistaPrevia}
+              className="h-14 rounded-lg border border-[#D97706] px-7 font-semibold text-[#D97706] hover:bg-orange-50"
             >
               Vista previa
             </button>
           </div>
 
-          <p className="mt-2 text-xs text-gray-500">
+          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <button
+              type="button"
+              onClick={() => setError('El video se actualizará al guardar multimedia')}
+              className="h-12 rounded-lg border border-[#D97706] font-semibold text-[#D97706] hover:bg-orange-50"
+            >
+              Cambiar video
+            </button>
+
+            <button
+              type="button"
+              onClick={handleEliminarVideo}
+              className="h-12 rounded-lg border border-red-400 font-semibold text-red-500 hover:bg-red-50"
+            >
+              Eliminar video
+            </button>
+          </div>
+
+          <p className="mt-3 text-sm text-gray-500">
             Puedes agregar un enlace de YouTube o Vimeo.
           </p>
         </div>
 
-        <div className="flex flex-col gap-3 border-t pt-5 sm:flex-row">
-          <button
-            type="button"
-            onClick={onClose}
-            className="h-11 flex-1 rounded-lg border border-gray-400 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            Cancelar
-          </button>
+        <div className="border-t border-gray-200 pt-6">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={guardando}
+              className="h-14 rounded-lg border border-gray-400 font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Cancelar
+            </button>
 
-          <button
-            type="button"
-            className="h-11 flex-1 rounded-lg bg-[#D97706] text-sm font-medium text-white hover:bg-[#bf6905]"
-          >
-            Guardar multimedia
-          </button>
+            <button
+              type="button"
+              onClick={handleGuardar}
+              disabled={guardando}
+              className="h-14 rounded-lg bg-[#D97706] font-semibold text-white hover:bg-[#bf6905] disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {guardando ? 'Guardando...' : 'Guardar multimedia'}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -49,6 +49,18 @@ const convertirArchivoABase64 = (file: File): Promise<string> => {
   })
 }
 
+const esVideoPermitido = (url: string) => {
+  const video = url.trim().toLowerCase()
+
+  if (!video) return true
+
+  return (
+    video.includes('youtube.com') ||
+    video.includes('youtu.be') ||
+    video.includes('vimeo.com')
+  )
+}
+
 const leerRespuesta = async (response: Response) => {
   const contentType = response.headers.get('content-type') ?? ''
 
@@ -80,6 +92,11 @@ export default function EditarMultimediaModal({
   const [imagenesNuevas, setImagenesNuevas] = useState<string[]>([])
   const [guardando, setGuardando] = useState(false)
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const totalImagenes = imagenes.length + imagenesNuevas.length
+  const videoTieneTexto = videoUrl.trim().length > 0
+  const videoValido = esVideoPermitido(videoUrl)
 
   useEffect(() => {
     if (open) {
@@ -87,12 +104,18 @@ export default function EditarMultimediaModal({
       setVideoUrl(videoActual ?? '')
       setImagenesNuevas([])
       setError('')
+      setSuccess('')
     }
   }, [open, imagenesActuales, videoActual])
 
   if (!open) return null
 
   const handleAgregarImagen = () => {
+    if (totalImagenes >= 10) {
+      setError('Has alcanzado el límite máximo de 10 imágenes.')
+      return
+    }
+
     inputFileRef.current?.click()
   }
 
@@ -104,21 +127,25 @@ export default function EditarMultimediaModal({
     if (!file) return
 
     setError('')
+    setSuccess('')
 
     const formatosPermitidos = ['image/jpeg', 'image/png', 'image/jpg']
 
     if (!formatosPermitidos.includes(file.type)) {
-      setError('Solo se permiten imágenes JPG o PNG')
+      setError('Formato no válido. Solo se permiten archivos JPG y PNG.')
+      event.target.value = ''
       return
     }
 
     if (file.size > 5 * 1024 * 1024) {
-      setError('La imagen no puede superar los 5MB')
+      setError('El archivo supera el tamaño máximo permitido de 5MB por imagen.')
+      event.target.value = ''
       return
     }
 
-    if (imagenes.length + imagenesNuevas.length >= 10) {
-      setError('Solo puedes tener hasta 10 imágenes')
+    if (totalImagenes >= 10) {
+      setError('Has alcanzado el límite máximo de 10 imágenes.')
+      event.target.value = ''
       return
     }
 
@@ -135,16 +162,28 @@ export default function EditarMultimediaModal({
   }
 
   const handleEliminarImagenActual = (index: number) => {
+    setError('')
+    setSuccess('')
     setImagenes((prev) => prev.filter((_, i) => i !== index))
   }
 
   const handleEliminarImagenNueva = (index: number) => {
+    setError('')
+    setSuccess('')
     setImagenesNuevas((prev) => prev.filter((_, i) => i !== index))
   }
 
   const handleVistaPrevia = () => {
+    setError('')
+    setSuccess('')
+
     if (!videoUrl.trim()) {
       setError('Primero ingresa un enlace de video')
+      return
+    }
+
+    if (!esVideoPermitido(videoUrl)) {
+      setError('Solo se permiten enlaces de YouTube o Plataformas permitidas.')
       return
     }
 
@@ -152,6 +191,8 @@ export default function EditarMultimediaModal({
   }
 
   const handleEliminarVideo = () => {
+    setError('')
+    setSuccess('')
     setVideoUrl('')
   }
 
@@ -159,12 +200,23 @@ export default function EditarMultimediaModal({
     try {
       setGuardando(true)
       setError('')
+      setSuccess('')
+
+      if (totalImagenes === 0) {
+        setError('La publicación debe tener al menos 1 imagen.')
+        return
+      }
+
+      if (videoUrl.trim() && !esVideoPermitido(videoUrl)) {
+        setError('Solo se permiten enlaces de YouTube o Plataformas permitidas.')
+        return
+      }
 
       const apiUrl = getApiUrl()
-const token = getToken()
+      const token = getToken()
 
-const response = await fetch(
-  `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
+      const response = await fetch(
+        `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
         {
           method: 'PUT',
           headers: {
@@ -187,8 +239,12 @@ const response = await fetch(
         )
       }
 
-      await onSaved()
-      onClose()
+      setSuccess('Contenido multimedia actualizado correctamente.')
+
+      setTimeout(async () => {
+        await onSaved()
+        onClose()
+      }, 900)
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'No se pudo guardar la multimedia'
@@ -209,7 +265,8 @@ const response = await fetch(
           <button
             type="button"
             onClick={onClose}
-            className="text-3xl leading-none text-gray-500 hover:text-gray-800"
+            disabled={guardando}
+            className="text-3xl leading-none text-gray-500 hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
           >
             ×
           </button>
@@ -221,10 +278,22 @@ const response = await fetch(
           </div>
         )}
 
+        {success && (
+          <div className="mb-6 rounded-lg border border-green-200 bg-green-50 px-5 py-4 text-green-700">
+            {success}
+          </div>
+        )}
+
         <div className="mb-8">
           <h3 className="mb-4 text-lg font-semibold text-gray-800">
-            Imágenes actuales ({imagenes.length + imagenesNuevas.length}/10)
+            Imágenes actuales ({totalImagenes}/10)
           </h3>
+
+          {totalImagenes >= 10 && (
+            <p className="mb-4 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
+              Has alcanzado el límite máximo de 10 imágenes.
+            </p>
+          )}
 
           <div className="flex flex-wrap gap-4">
             {imagenes.map((imagen, index) => (
@@ -241,7 +310,8 @@ const response = await fetch(
                 <button
                   type="button"
                   onClick={() => handleEliminarImagenActual(index)}
-                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70"
+                  disabled={guardando}
+                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   ×
                 </button>
@@ -262,23 +332,23 @@ const response = await fetch(
                 <button
                   type="button"
                   onClick={() => handleEliminarImagenNueva(index)}
-                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70"
+                  disabled={guardando}
+                  className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   ×
                 </button>
               </div>
             ))}
 
-            {imagenes.length + imagenesNuevas.length < 10 && (
-              <button
-                type="button"
-                onClick={handleAgregarImagen}
-                className="flex h-36 w-44 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 bg-white text-gray-700 hover:bg-gray-50"
-              >
-                <span className="text-3xl font-bold">+</span>
-                <span className="mt-3 text-lg">Agregar imagen</span>
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={handleAgregarImagen}
+              disabled={guardando || totalImagenes >= 10}
+              className="flex h-36 w-44 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 bg-white text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="text-3xl font-bold">+</span>
+              <span className="mt-3 text-lg">Agregar imagen</span>
+            </button>
           </div>
 
           <input
@@ -304,25 +374,43 @@ const response = await fetch(
             <input
               type="url"
               value={videoUrl}
-              onChange={(e) => setVideoUrl(e.target.value)}
+              onChange={(e) => {
+                setVideoUrl(e.target.value)
+                setError('')
+                setSuccess('')
+              }}
               placeholder="https://www.youtube.com/watch?v=..."
-              className="h-14 flex-1 rounded-lg border border-gray-300 px-4 text-lg outline-none focus:border-[#D97706]"
+              className={`h-14 flex-1 rounded-lg border px-4 text-lg outline-none focus:border-[#D97706] ${
+                videoTieneTexto && !videoValido
+                  ? 'border-red-400'
+                  : 'border-gray-300'
+              }`}
             />
 
             <button
               type="button"
               onClick={handleVistaPrevia}
-              className="h-14 rounded-lg border border-[#D97706] px-7 font-semibold text-[#D97706] hover:bg-orange-50"
+              disabled={guardando || !videoTieneTexto || !videoValido}
+              className="h-14 rounded-lg border border-[#D97706] px-7 font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Vista previa
             </button>
           </div>
 
+          {videoTieneTexto && !videoValido && (
+            <p className="mt-3 text-sm text-red-600">
+              Solo se permiten enlaces de YouTube o Plataformas permitidas.
+            </p>
+          )}
+
           <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
             <button
               type="button"
-              onClick={() => setError('El video se actualizará al guardar multimedia')}
-              className="h-12 rounded-lg border border-[#D97706] font-semibold text-[#D97706] hover:bg-orange-50"
+              onClick={() =>
+                setError('El video se actualizará al guardar multimedia')
+              }
+              disabled={guardando || !videoTieneTexto || !videoValido}
+              className="h-12 rounded-lg border border-[#D97706] font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Cambiar video
             </button>
@@ -330,7 +418,8 @@ const response = await fetch(
             <button
               type="button"
               onClick={handleEliminarVideo}
-              className="h-12 rounded-lg border border-red-400 font-semibold text-red-500 hover:bg-red-50"
+              disabled={guardando || !videoTieneTexto}
+              className="h-12 rounded-lg border border-red-400 font-semibold text-red-500 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Eliminar video
             </button>

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import type { PublicacionImagen } from '@/types/publicacion'
+
+type EditarMultimediaModalProps = {
+  open: boolean
+  imagenesActuales: PublicacionImagen[]
+  videoActual?: string | null
+  onClose: () => void
+}
+
+export default function EditarMultimediaModal({
+  open,
+  imagenesActuales,
+  videoActual,
+  onClose
+}: EditarMultimediaModalProps) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
+      <div className="w-full max-w-3xl rounded-2xl bg-white p-6 shadow-2xl">
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-black">
+            Editar imágenes y video
+          </h2>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-2xl text-gray-500 hover:text-black"
+          >
+            ×
+          </button>
+        </div>
+
+        <h3 className="mb-3 text-sm font-semibold text-gray-800">
+          Imágenes actuales ({imagenesActuales.length}/10)
+        </h3>
+
+        <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4 md:grid-cols-5">
+          {imagenesActuales.map((imagen) => (
+            <div
+              key={imagen.id}
+              className="relative h-28 overflow-hidden rounded-xl border border-gray-200"
+            >
+              <img
+                src={imagen.url}
+                alt="Imagen de publicación"
+                className="h-full w-full object-cover"
+              />
+
+              <button
+                type="button"
+                className="absolute right-1 top-1 rounded-full bg-black/50 px-2 py-1 text-xs text-white"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className="flex h-28 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            <span className="text-2xl font-bold">+</span>
+            Agregar imagen
+          </button>
+        </div>
+
+        <p className="mb-6 text-xs text-gray-500">
+          Puedes subir hasta 10 imágenes. Formatos: JPG, PNG. Tamaño máximo:
+          5MB por imagen.
+        </p>
+
+        <div className="mb-6">
+          <label className="mb-2 block text-sm font-semibold text-gray-800">
+            Video de la propiedad opcional
+          </label>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              defaultValue={videoActual ?? ''}
+              placeholder="Pega un enlace de YouTube o Vimeo"
+              className="h-11 flex-1 rounded-lg border border-gray-300 px-4 outline-none focus:border-[#D97706]"
+            />
+
+            <button
+              type="button"
+              className="h-11 rounded-lg border border-[#D97706] px-4 text-sm font-semibold text-[#D97706] hover:bg-orange-50"
+            >
+              Vista previa
+            </button>
+          </div>
+
+          <p className="mt-2 text-xs text-gray-500">
+            Puedes agregar un enlace de YouTube o Vimeo.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t pt-5 sm:flex-row">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-11 flex-1 rounded-lg border border-gray-400 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancelar
+          </button>
+
+          <button
+            type="button"
+            className="h-11 flex-1 rounded-lg bg-[#D97706] text-sm font-medium text-white hover:bg-[#bf6905]"
+          >
+            Guardar multimedia
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/publicacion/EditarMultimediaModal.tsx
+++ b/frontend/src/components/publicacion/EditarMultimediaModal.tsx
@@ -11,6 +11,9 @@ type EditarMultimediaModalProps = {
   onSaved: () => void | Promise<void>
 }
 
+const LIMITE_IMAGENES = 5
+const LIMITE_VIDEOS = 2
+
 const getApiUrl = () => {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL
 
@@ -88,20 +91,20 @@ export default function EditarMultimediaModal({
   const inputFileRef = useRef<HTMLInputElement | null>(null)
 
   const [imagenes, setImagenes] = useState<string[]>([])
-  const [videoUrl, setVideoUrl] = useState('')
+  const [videosUrl, setVideosUrl] = useState<string[]>(['', ''])
   const [imagenesNuevas, setImagenesNuevas] = useState<string[]>([])
   const [guardando, setGuardando] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
   const totalImagenes = imagenes.length + imagenesNuevas.length
-  const videoTieneTexto = videoUrl.trim().length > 0
-  const videoValido = esVideoPermitido(videoUrl)
+  const videosValidos = videosUrl.every((video) => esVideoPermitido(video))
+  const videosConTexto = videosUrl.filter((video) => video.trim()).length
 
   useEffect(() => {
     if (open) {
       setImagenes(imagenesActuales ?? [])
-      setVideoUrl(videoActual ?? '')
+      setVideosUrl([videoActual ?? '', ''])
       setImagenesNuevas([])
       setError('')
       setSuccess('')
@@ -111,8 +114,8 @@ export default function EditarMultimediaModal({
   if (!open) return null
 
   const handleAgregarImagen = () => {
-    if (totalImagenes >= 10) {
-      setError('Has alcanzado el límite máximo de 10 imágenes.')
+    if (totalImagenes >= LIMITE_IMAGENES) {
+      setError(`Has alcanzado el límite máximo de ${LIMITE_IMAGENES} imágenes.`)
       return
     }
 
@@ -143,8 +146,8 @@ export default function EditarMultimediaModal({
       return
     }
 
-    if (totalImagenes >= 10) {
-      setError('Has alcanzado el límite máximo de 10 imágenes.')
+    if (totalImagenes >= LIMITE_IMAGENES) {
+      setError(`Has alcanzado el límite máximo de ${LIMITE_IMAGENES} imágenes.`)
       event.target.value = ''
       return
     }
@@ -173,7 +176,17 @@ export default function EditarMultimediaModal({
     setImagenesNuevas((prev) => prev.filter((_, i) => i !== index))
   }
 
-  const handleVistaPrevia = () => {
+  const handleCambiarVideo = (index: number, value: string) => {
+    setVideosUrl((prev) =>
+      prev.map((video, videoIndex) => (videoIndex === index ? value : video))
+    )
+    setError('')
+    setSuccess('')
+  }
+
+  const handleVistaPrevia = (index: number) => {
+    const videoUrl = videosUrl[index]
+
     setError('')
     setSuccess('')
 
@@ -190,10 +203,12 @@ export default function EditarMultimediaModal({
     window.open(videoUrl.trim(), '_blank', 'noopener,noreferrer')
   }
 
-  const handleEliminarVideo = () => {
+  const handleEliminarVideo = (index: number) => {
     setError('')
     setSuccess('')
-    setVideoUrl('')
+    setVideosUrl((prev) =>
+      prev.map((video, videoIndex) => (videoIndex === index ? '' : video))
+    )
   }
 
   const handleGuardar = async () => {
@@ -207,13 +222,22 @@ export default function EditarMultimediaModal({
         return
       }
 
-      if (videoUrl.trim() && !esVideoPermitido(videoUrl)) {
+      if (!videosValidos) {
         setError('Solo se permiten enlaces de YouTube o Plataformas permitidas.')
+        return
+      }
+
+      if (videosConTexto > LIMITE_VIDEOS) {
+        setError(`Solo se permiten hasta ${LIMITE_VIDEOS} enlaces de video.`)
         return
       }
 
       const apiUrl = getApiUrl()
       const token = getToken()
+
+      const videosLimpios = videosUrl
+        .map((video) => video.trim())
+        .filter(Boolean)
 
       const response = await fetch(
         `${apiUrl}/api/publicaciones/${publicacionId}/multimedia`,
@@ -226,7 +250,8 @@ export default function EditarMultimediaModal({
           body: JSON.stringify({
             imagenesActuales: imagenes,
             imagenesNuevas,
-            videoUrl: videoUrl.trim() || null
+            videoUrl: videosLimpios[0] ?? null,
+            videoUrls: videosLimpios
           })
         }
       )
@@ -286,12 +311,12 @@ export default function EditarMultimediaModal({
 
         <div className="mb-8">
           <h3 className="mb-4 text-lg font-semibold text-gray-800">
-            Imágenes actuales ({totalImagenes}/10)
+            Imágenes actuales ({totalImagenes}/{LIMITE_IMAGENES})
           </h3>
 
-          {totalImagenes >= 10 && (
+          {totalImagenes >= LIMITE_IMAGENES && (
             <p className="mb-4 rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
-              Has alcanzado el límite máximo de 10 imágenes.
+              Has alcanzado el límite máximo de {LIMITE_IMAGENES} imágenes.
             </p>
           )}
 
@@ -343,7 +368,7 @@ export default function EditarMultimediaModal({
             <button
               type="button"
               onClick={handleAgregarImagen}
-              disabled={guardando || totalImagenes >= 10}
+              disabled={guardando || totalImagenes >= LIMITE_IMAGENES}
               className="flex h-36 w-44 flex-col items-center justify-center rounded-xl border border-dashed border-gray-400 bg-white text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span className="text-3xl font-bold">+</span>
@@ -360,74 +385,88 @@ export default function EditarMultimediaModal({
           />
 
           <p className="mt-4 text-sm text-gray-500">
-            Puedes subir hasta 10 imágenes. Formatos: JPG, PNG. Tamaño máximo:
-            5MB por imagen.
+            Puedes subir hasta {LIMITE_IMAGENES} imágenes. Formatos: JPG, PNG.
+            Tamaño máximo: 5MB por imagen.
           </p>
         </div>
 
         <div className="mb-8">
           <h3 className="mb-3 text-lg font-semibold text-gray-800">
-            Video de la propiedad opcional
+            Videos de la propiedad opcional
           </h3>
 
-          <div className="flex flex-col gap-4 md:flex-row">
-            <input
-              type="url"
-              value={videoUrl}
-              onChange={(e) => {
-                setVideoUrl(e.target.value)
-                setError('')
-                setSuccess('')
-              }}
-              placeholder="https://www.youtube.com/watch?v=..."
-              className={`h-14 flex-1 rounded-lg border px-4 text-lg outline-none focus:border-[#D97706] ${
-                videoTieneTexto && !videoValido
-                  ? 'border-red-400'
-                  : 'border-gray-300'
-              }`}
-            />
-
-            <button
-              type="button"
-              onClick={handleVistaPrevia}
-              disabled={guardando || !videoTieneTexto || !videoValido}
-              className="h-14 rounded-lg border border-[#D97706] px-7 font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Vista previa
-            </button>
-          </div>
-
-          {videoTieneTexto && !videoValido && (
-            <p className="mt-3 text-sm text-red-600">
-              Solo se permiten enlaces de YouTube o Plataformas permitidas.
-            </p>
-          )}
-
-          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-            <button
-              type="button"
-              onClick={() =>
-                setError('El video se actualizará al guardar multimedia')
-              }
-              disabled={guardando || !videoTieneTexto || !videoValido}
-              className="h-12 rounded-lg border border-[#D97706] font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Cambiar video
-            </button>
-
-            <button
-              type="button"
-              onClick={handleEliminarVideo}
-              disabled={guardando || !videoTieneTexto}
-              className="h-12 rounded-lg border border-red-400 font-semibold text-red-500 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Eliminar video
-            </button>
-          </div>
-
-          <p className="mt-3 text-sm text-gray-500">
-            Puedes agregar un enlace de YouTube o Vimeo.
+          <p className="mb-4 text-sm text-gray-500">
+            Puedes agregar hasta {LIMITE_VIDEOS} enlaces de YouTube o Vimeo.
           </p>
+
+          <div className="space-y-5">
+            {videosUrl.map((video, index) => {
+              const videoTieneTexto = video.trim().length > 0
+              const videoValido = esVideoPermitido(video)
+
+              return (
+                <div key={`video-${index}`} className="space-y-3">
+                  <label className="block text-sm font-semibold text-gray-700">
+                    Video {index + 1}
+                  </label>
+
+                  <div className="flex flex-col gap-4 md:flex-row">
+                    <input
+                      type="url"
+                      value={video}
+                      onChange={(e) => handleCambiarVideo(index, e.target.value)}
+                      placeholder="https://www.youtube.com/watch?v=..."
+                      className={`h-14 flex-1 rounded-lg border px-4 text-lg outline-none focus:border-[#D97706] ${
+                        videoTieneTexto && !videoValido
+                          ? 'border-red-400'
+                          : 'border-gray-300'
+                      }`}
+                    />
+
+                    <button
+                      type="button"
+                      onClick={() => handleVistaPrevia(index)}
+                      disabled={guardando || !videoTieneTexto || !videoValido}
+                      className="h-14 rounded-lg border border-[#D97706] px-7 font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Vista previa
+                    </button>
+                  </div>
+
+                  {videoTieneTexto && !videoValido && (
+                    <p className="text-sm text-red-600">
+                      Solo se permiten enlaces de YouTube o Plataformas
+                      permitidas.
+                    </p>
+                  )}
+
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setError(
+                          'El video se actualizará al guardar multimedia'
+                        )
+                      }
+                      disabled={guardando || !videoTieneTexto || !videoValido}
+                      className="h-12 rounded-lg border border-[#D97706] font-semibold text-[#D97706] hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Cambiar video
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => handleEliminarVideo(index)}
+                      disabled={guardando || !videoTieneTexto}
+                      className="h-12 rounded-lg border border-red-400 font-semibold text-red-500 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Eliminar video
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
         </div>
 
         <div className="border-t border-gray-200 pt-6">
@@ -451,8 +490,6 @@ export default function EditarMultimediaModal({
             </button>
           </div>
         </div>
-       
-        
       </div>
     </div>
   )

--- a/frontend/src/services/publicacion.service.ts
+++ b/frontend/src/services/publicacion.service.ts
@@ -108,3 +108,27 @@ export async function eliminarPublicacion(id: number) {
 
   return data
 }
+
+export async function editarMultimediaPublicacion(
+  id: number,
+  formData: FormData
+) {
+  const apiUrl = getApiUrl()
+  const token = getToken()
+
+  const response = await fetch(`${apiUrl}/api/publicaciones/${id}/multimedia`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: formData
+  })
+
+  const data = await response.json()
+
+  if (!response.ok) {
+    throw new Error(data.message || 'No se pudo actualizar la multimedia')
+  }
+
+  return data.data
+}

--- a/frontend/src/types/publicacion.ts
+++ b/frontend/src/types/publicacion.ts
@@ -17,55 +17,38 @@ export interface MisPublicacionesItem {
 }
 
 export interface FormPublicar {
-  titulo: string;
-  tipoPropiedad: string;
-  precio: string;
-  superficie: string;
-  habitaciones: string;
-  banos: string;
-  direccion: string;
-  ciudad: string;
-  codigoPostal: string;
-  descripcion: string;
+  titulo: string
+  tipoPropiedad: string
+  precio: string
+  superficie: string
+  habitaciones: string
+  banos: string
+  direccion: string
+  ciudad: string
+  codigoPostal: string
+  descripcion: string
 }
 
 export interface ErrorValidacion {
-  campo: keyof FormPublicar;
-  seccion: "Información Básica" | "Características" | "Ubicación" | "Detalles";
-  mensaje: string;
+  campo: keyof FormPublicar
+  seccion: 'Información Básica' | 'Características' | 'Ubicación' | 'Detalles'
+  mensaje: string
 }
 
 export type EstadoPublicacion =
-  | "idle"
-  | "validando"
-  | "errores"
-  | "confirmando"
-  | "publicando"
-  | "exito"
-  | "error_publicacion";
+  | 'idle'
+  | 'validando'
+  | 'errores'
+  | 'confirmando'
+  | 'publicando'
+  | 'exito'
+  | 'error_publicacion'
 
-
-export interface PublicacionDetalle {
+export interface PublicacionImagen {
   id: number
-  titulo: string
-  descripcion: string
-  precio: number
-  tipoOperacion: 'VENTA' | 'ALQUILER' | 'ANTICRETO'
-  ubicacionTexto: string
-  imagenes: Array<{
-    id: number
-    url: string
-    tipo: string
-    pesoMb: number | null
-  }>
-}
-
-export interface EditarPublicacionPayload {
-  titulo: string
-  descripcion: string
-  precio: number
-  tipoAccion: 'VENTA' | 'ALQUILER' | 'ANTICRETO'
-  ubicacion: string
+  url: string
+  tipo: string
+  pesoMb: number | null
 }
 
 export interface PublicacionDetalle {
@@ -75,12 +58,8 @@ export interface PublicacionDetalle {
   precio: number
   tipoOperacion: 'VENTA' | 'ALQUILER' | 'ANTICRETO'
   ubicacionTexto: string
-  imagenes: Array<{
-    id: number
-    url: string
-    tipo: string
-    pesoMb: number | null
-  }>
+  imagenes: PublicacionImagen[]
+  videoUrl?: string | null
 }
 
 export interface EditarPublicacionPayload {


### PR DESCRIPTION
Se implementan mejoras en la edición de multimedia de publicaciones.

Cambios realizados:
- Se limita la cantidad máxima de imágenes a 5.
- Se permite gestionar hasta 2 enlaces de video.
- Se agregan validaciones para formato y tamaño de imágenes.
- Se valida que los videos sean enlaces permitidos de YouTube o Vimeo.
- Se permite guardar imágenes aunque exista un problema con el enlace de video.
- Se actualiza la lógica backend para persistir imágenes nuevas correctamente.
- Se mantiene la edición multimedia sin afectar título, descripción, precio ni ubicación de la publicación.

Pruebas realizadas:
- Verificación de TypeScript en frontend.
- Verificación de TypeScript en backend.
- Prueba local de guardado de imágenes y videos.