### PR TITLE
Feature/mapas hu10 w

### DIFF
--- a/frontend/src/components/map/ZonasOverlay.tsx
+++ b/frontend/src/components/map/ZonasOverlay.tsx
@@ -61,7 +61,8 @@ function centroide(coords: [number, number][]): [number, number] {
 function dimensionarEtiqueta(
   nombre: string,
   zoom: number,
-  isSelected: boolean
+  isSelected: boolean,
+  tipoZona: TipoZona = 'predefinida'
 ): {
   width: number
   height: number
@@ -80,7 +81,11 @@ function dimensionarEtiqueta(
   // Para zoom=13: 0.64, para zoom=18: ~1.02, para zoom<13: reduce hasta 0.36
   const zoomOffset = Math.max(-MIN_ZOOM_LABELS, zoom - MIN_ZOOM_LABELS) // Puede ser negativo
   const zoomProportional = 0.70 + (zoomOffset / 8) * 0.40 // Rango: 0.36 a ~1.02
-  const scale = Math.max(0.40, Math.min(1.12, zoomProportional + selectedBoost))
+  let scale = Math.max(0.40, Math.min(1.12, zoomProportional + selectedBoost))
+
+   if (tipoZona === 'personalizada') {
+    scale = scale * 1.2
+  }
 
   const paddingX = Math.round((8 * scale) * 10) / 10
   const paddingY = Math.round((5 * scale) * 10) / 10
@@ -245,7 +250,7 @@ function labelIcon(nombre: string, isSelected: boolean, zoom: number, tipoZona: 
     paddingX,
     paddingY,
     maxCharsPorLinea
-  } = dimensionarEtiqueta(nombreVisible, zoom, isSelected)
+  } = dimensionarEtiqueta(nombreVisible, zoom, isSelected, tipoZona)
   const textoHtml = htmlEtiquetaConWrap(nombreVisible, maxCharsPorLinea)
   const nombreCompletoEscapado = escaparHtml(nombre)
   

--- a/frontend/src/types/zona.ts
+++ b/frontend/src/types/zona.ts
@@ -36,7 +36,7 @@ export const ZONA_COLORS = {
     borderActive: '#16a34a',
     fillActive: '#22c55e',
     fillOpacityActive: 0.28,
-    labelColor: '#16A34A',
-    labelColorSelected: '#16A34A'
+    labelColor: '#15803D',
+    labelColorSelected: '#15803D'
   }
 } as const

--- a/frontend/src/types/zona.ts
+++ b/frontend/src/types/zona.ts
@@ -36,7 +36,7 @@ export const ZONA_COLORS = {
     borderActive: '#16a34a',
     fillActive: '#22c55e',
     fillOpacityActive: 0.28,
-    labelColor: '#16a34a',
-    labelColorSelected: '#16a34a'
+    labelColor: '#16A34A',
+    labelColorSelected: '#16A34A'
   }
 } as const


### PR DESCRIPTION
Aumento de tamaño de etiquetas (solo zonas personalizadas)
Las etiquetas de zonas personalizadas ahora son 20% más grandes que las predefinidas
Mejora significativa en la legibilidad de nombres de zonas creadas por usuarios
Las zonas predefinidas mantienen su tamaño original