### PR TITLE
fix/overlaysRefinados

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -445,7 +445,13 @@ html.propbol-theme-dark body :where([class*="bg-white"],
   [class*="bg-[#D"],
   [class*="bg-[#d"],
   [class*="bg-[#E7"],
-  [class*="bg-[#e7"]) {
+  [class*="bg-[#e7"],
+  [class*="bg-[#fb"],
+  [class*="bg-[#FB"],
+  [class*="bg-[#f5"],
+  [class*="bg-[#F5"],
+  [class*="bg-[#f8"],
+  [class*="bg-[#F8"]) {
   background: var(--pb-surface) !important;
   background-image: none !important;
   color: var(--pb-text) !important;
@@ -711,8 +717,14 @@ html.propbol-theme-dark .propbol-btn-close-session:hover {
 }
 
 /* Fix para botones naranjas y overlays en modo oscuro */
-html.propbol-theme-dark body :where([class*="bg-[#D97706]"], [class*="bg-primary"]) {
+html.propbol-theme-dark body :where([class*="bg-orange-500"], [class*="bg-orange-600"], [class*="bg-amber-"], [class*="bg-primary"], [class*="bg-[#A67C00]"], [class*="bg-[#D97706]"], [class*="bg-stone-900"]) {
   background: var(--pb-accent) !important;
   color: #ffffff !important;
   border-color: var(--pb-accent) !important;
+}
+
+/* Forzar fondo oscuro en contenedores con gradientes específicos de blogs */
+html.propbol-theme-dark :where([class*="bg-[linear-gradient"]) {
+  background: var(--pb-bg) !important;
+  background-image: none !important;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -728,3 +728,34 @@ html.propbol-theme-dark :where([class*="bg-[linear-gradient"]) {
   background: var(--pb-bg) !important;
   background-image: none !important;
 }
+
+/* Protegemos colores semánticos sin afectar al modo claro */
+html.propbol-theme-dark body :where([class*="bg-[#E8F7EE]"], [class*="bg-green-50"]) {
+  background: rgba(22, 101, 52, 0.25) !important;
+  color: #86efac !important;
+  border-color: rgba(34, 197, 94, 0.4) !important;
+}
+
+html.propbol-theme-dark body :where([class*="bg-[#FDECEC]"], [class*="bg-red-50"]) {
+  background: rgba(127, 29, 29, 0.25) !important;
+  color: #fca5a5 !important;
+  border-color: rgba(239, 68, 68, 0.4) !important;
+}
+
+html.propbol-theme-dark body :where([class*="bg-amber-50"]) {
+  background: rgba(120, 53, 15, 0.25) !important;
+  color: #fcd34d !important;
+  border-color: rgba(217, 119, 6, 0.4) !important;
+}
+
+html.propbol-theme-dark body :where([class*="text-green-600"], [class*="text-[#198754]"]) {
+  color: #86efac !important;
+}
+
+html.propbol-theme-dark body :where([class*="text-amber-600"], [class*="text-amber-700"]) {
+  color: #fbbf24 !important;
+}
+
+html.propbol-theme-dark body :where([class*="text-red-600"], [class*="text-[#D94848]"]) {
+  color: #fca5a5 !important;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -429,6 +429,7 @@ html.propbol-theme-dark .propbol-active-sessions-page {
 html.propbol-theme-dark body :where([class*="bg-white"],
   [class*="bg-gray"],
   [class*="bg-slate"],
+  [class*="text-slate"],
   [class*="bg-neutral"],
   [class*="bg-zinc"],
   [class*="bg-stone"],
@@ -451,7 +452,7 @@ html.propbol-theme-dark body :where([class*="bg-white"],
   [class*="bg-[#f5"],
   [class*="bg-[#F5"],
   [class*="bg-[#f8"],
-  [class*="bg-[#F8"]) {
+  [class*="bg-[#F8"]):not([class*="/"]) {
   background: var(--pb-surface) !important;
   background-image: none !important;
   color: var(--pb-text) !important;
@@ -717,11 +718,12 @@ html.propbol-theme-dark .propbol-btn-close-session:hover {
 }
 
 /* Fix para botones naranjas y overlays en modo oscuro */
-html.propbol-theme-dark body :where([class*="bg-orange-500"], [class*="bg-orange-600"], [class*="bg-amber-"], [class*="bg-primary"], [class*="bg-[#A67C00]"], [class*="bg-[#D97706]"], [class*="bg-stone-900"]) {
+html.propbol-theme-dark body :where([class*="bg-orange-500"], [class*="bg-orange-600"], [class*="bg-amber-"], [class*="bg-primary"], [class*="bg-[#A67C00]"], [class*="bg-[#D97706]"]) {
   background: var(--pb-accent) !important;
   color: #ffffff !important;
   border-color: var(--pb-accent) !important;
 }
+
 
 /* Forzar fondo oscuro en contenedores con gradientes específicos de blogs */
 html.propbol-theme-dark :where([class*="bg-[linear-gradient"]) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16,12 +16,18 @@
 
 @layer base {
   :root {
-    --primary: 31 100% 50%; /* #D97706 - Ámbar para acentos */
-    --background: 0 0% 100%; /* #ffffff - Blanco */
-    --foreground: 20 6% 15%; /* #292524 - Stone-900 para títulos */
-    --muted: 30 5% 45%; /* #78716c - Stone-600 para texto secundario */
-    --border: 30 10% 96%; /* #f5f5f4 - Stone-100 para bordes */
-    --card: 0 0% 100%; /* #ffffff - Blanco para superficies */
+    --primary: 31 100% 50%;
+    /* #D97706 - Ámbar para acentos */
+    --background: 0 0% 100%;
+    /* #ffffff - Blanco */
+    --foreground: 20 6% 15%;
+    /* #292524 - Stone-900 para títulos */
+    --muted: 30 5% 45%;
+    /* #78716c - Stone-600 para texto secundario */
+    --border: 30 10% 96%;
+    /* #f5f5f4 - Stone-100 para bordes */
+    --card: 0 0% 100%;
+    /* #ffffff - Blanco para superficies */
   }
 
   body {
@@ -36,9 +42,11 @@
 }
 
 @layer utilities {
+
   /* Acentos - Ámbar */
   .bg-primary {
-    background-color: #d97706; /* amber-600 */
+    background-color: #d97706;
+    /* amber-600 */
   }
 
   .font-heading {
@@ -106,9 +114,11 @@
   .cluster-bubble--high {
     /* verde   ≥ 10 */
   }
+
   .cluster-bubble--medium {
     /* naranja 2-9  */
   }
+
   .cluster-bubble--low {
     /* azul    1    */
   }
@@ -136,6 +146,7 @@
   .leaflet-popup {
     z-index: 1001 !important;
   }
+
   /* Commit 1: tamaño clusters móvil */
   @media (max-width: 768px) {
     .cluster-bubble {
@@ -146,6 +157,7 @@
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
     }
   }
+
   /* Commit 2: sin hover en touch */
   @media (max-width: 768px) {
     .cluster-bubble:hover {
@@ -153,29 +165,34 @@
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
     }
   }
+
   /* Commit 3: popup móvil */
   @media (max-width: 768px) {
     .leaflet-popup-content-wrapper {
       max-width: 220px;
       border-radius: 12px;
     }
+
     .leaflet-popup-content {
       margin: 10px 12px;
       font-size: 13px;
       line-height: 1.4;
       word-break: break-word;
     }
+
     .leaflet-popup-tip {
       width: 10px;
       height: 10px;
     }
   }
+
   /* Commit 4: controles y animaciones */
   @media (max-width: 768px) {
     .leaflet-control-zoom {
       transform: scale(0.9);
       transform-origin: bottom right;
     }
+
     .leaflet-marker-icon,
     .leaflet-marker-shadow,
     .leaflet-cluster-anim .leaflet-marker-icon,
@@ -185,6 +202,7 @@
         opacity 250ms ease;
     }
   }
+
   /* Commit 5: celulares pequeños ≤480px */
   @media (max-width: 480px) {
     .cluster-bubble {
@@ -193,13 +211,16 @@
       font-size: 11px;
       border-width: 2px;
     }
+
     .leaflet-popup-content-wrapper {
       max-width: 180px;
     }
+
     .leaflet-popup-content {
       margin: 8px 10px;
       font-size: 12px;
     }
+
     .leaflet-control-zoom {
       transform: scale(0.85);
     }
@@ -231,9 +252,11 @@
 .cluster-bubble--high {
   /* verde   ≥ 10 */
 }
+
 .cluster-bubble--medium {
   /* naranja 2-9  */
 }
+
 .cluster-bubble--low {
   /* azul    1    */
 }
@@ -261,6 +284,7 @@
 .leaflet-popup {
   z-index: 1001 !important;
 }
+
 /* Commit 1: tamaño clusters móvil */
 @media (max-width: 768px) {
   .cluster-bubble {
@@ -271,6 +295,7 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
   }
 }
+
 /* Commit 2: sin hover en touch */
 @media (max-width: 768px) {
   .cluster-bubble:hover {
@@ -278,29 +303,34 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
   }
 }
+
 /* Commit 3: popup móvil */
 @media (max-width: 768px) {
   .leaflet-popup-content-wrapper {
     max-width: 220px;
     border-radius: 12px;
   }
+
   .leaflet-popup-content {
     margin: 10px 12px;
     font-size: 13px;
     line-height: 1.4;
     word-break: break-word;
   }
+
   .leaflet-popup-tip {
     width: 10px;
     height: 10px;
   }
 }
+
 /* Commit 4: controles y animaciones */
 @media (max-width: 768px) {
   .leaflet-control-zoom {
     transform: scale(0.9);
     transform-origin: bottom right;
   }
+
   .leaflet-marker-icon,
   .leaflet-marker-shadow,
   .leaflet-cluster-anim .leaflet-marker-icon,
@@ -310,6 +340,7 @@
       opacity 250ms ease;
   }
 }
+
 /* Commit 5: celulares pequeños ≤480px */
 @media (max-width: 480px) {
   .cluster-bubble {
@@ -318,21 +349,31 @@
     font-size: 11px;
     border-width: 2px;
   }
+
   .leaflet-popup-content-wrapper {
     max-width: 180px;
   }
+
   .leaflet-popup-content {
     margin: 8px 10px;
     font-size: 12px;
   }
+
   .leaflet-control-zoom {
     transform: scale(0.85);
   }
 }
+
 @keyframes fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
+
 .animate-fade {
   animation: fade-in 0.6s ease-in-out;
 }
@@ -661,10 +702,17 @@ html.propbol-theme-dark .propbol-btn-close-session:hover {
 .leaflet-gesture-handling-scroll-warning::after,
 .leaflet-container[data-gesture-handling-touch-warning]::after,
 .leaflet-container[data-gesture-handling-scroll-warning]::after {
-    display: none !important;
-    content: none !important;
-    opacity: 0 !important;
-    visibility: hidden !important;
-    background: transparent !important;
-    pointer-events: none !important;
+  display: none !important;
+  content: none !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+  background: transparent !important;
+  pointer-events: none !important;
+}
+
+/* Fix para botones naranjas y overlays en modo oscuro */
+html.propbol-theme-dark body :where([class*="bg-[#D97706]"], [class*="bg-primary"]) {
+  background: var(--pb-accent) !important;
+  color: #ffffff !important;
+  border-color: var(--pb-accent) !important;
 }

--- a/frontend/src/components/blog/BlogCard.tsx
+++ b/frontend/src/components/blog/BlogCard.tsx
@@ -55,7 +55,7 @@ export default function BlogCard({
             alt={title}
             className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
           />
-          <div className="absolute inset-0 bg-stone-900/5 transition-opacity duration-500 group-hover:opacity-0" />
+          <div className="absolute inset-0 bg-black/5 transition-opacity duration-500 group-hover:opacity-0" />
         </div>
 
         <div className="flex flex-1 flex-col p-6 sm:p-8">


### PR DESCRIPTION
El problema:
La regla global del modo oscuro estaba forzando que cualquier clase que empezara por bg-stone (como la que usa el fondo del modal: bg-stone-900/40) se convirtiera en un color sólido y opaco. Esto eliminaba el efecto de transparencia y difuminado, dejando un fondo naranja sólido (que era el color de acento que accidentalmente se aplicó también a esas capas).

La solución:
Protección de Opacidad: He refinado la regla principal de globals.css añadiendo :not([class*="/"]). Esto le dice al navegador: "Convierte los fondos claros a oscuro solo si no tienen una barra /". Las clases con / (como bg-stone-900/40 o bg-black/50) ahora son ignoradas por la regla global, permitiendo que Tailwind aplique su transparencia y el efecto backdrop-blur original.
Limpieza de Acentos: Eliminé la regla que forzaba el color naranja en las capas stone-900, restaurando la sobriedad necesaria para los overlays.