### PR TITLE
fix: Optimización del layout dinámico y bloqueo de resize en filtros

### DIFF
--- a/frontend/src/app/busqueda_mapa/page.tsx
+++ b/frontend/src/app/busqueda_mapa/page.tsx
@@ -1558,7 +1558,11 @@ function BusquedaMapaContent() {
           className={`bg-white border-r border-stone-200 flex flex-col z-10 transition-[width] duration-200 min-h-0 overflow-hidden ${
             isSidebarOpen ? 'w-full md:h-full h-[65dvh]' : 'w-0'
           }`}
-          style={isSidebarOpen ? { width: isMounted ? effectiveSidebarWidth : 450 } : { width: 0 }}
+          style={
+            isSidebarOpen 
+              ? { width: isMounted ? (activeSidebarView === 'results' && !isPriceFilterOpen ? effectiveSidebarWidth : 450) : 450 } 
+              : { width: 0 }
+          }
         >
           {/* ✅ MODIFICADO: ternario que alterna entre filtro de precio y resultados */}
           {isPriceFilterOpen ? (
@@ -1959,8 +1963,8 @@ function BusquedaMapaContent() {
           ) : null}
         </aside>
 
-        {/* Divider resizable (solo desktop con sidebar abierto) */}
-        {isSidebarOpen && (
+        {/* Divider resizable (solo desktop con sidebar abierto, en vista de resultados y si Precio está cerrado) */}
+        {isSidebarOpen && activeSidebarView === 'results' && !isPriceFilterOpen && (
           <div
             className="hidden md:block w-1 bg-stone-200 hover:bg-orange-300 active:bg-orange-400 cursor-col-resize relative z-20"
             onMouseDown={(e) => {


### PR DESCRIPTION
Cambios principales:


Ancho Condicional: Se modificó la lógica de estilos del <aside> para que el ancho personalizado (arrastrable) solo se aplique en la vista results. Si el usuario abre cualquier otro filtro o el panel de Precio, el contenedor vuelve automáticamente a un ancho fijo de 450px.  

Visibilidad del Divider: Se añadió una condición doble para el "agarrador" del resize. Ahora, la barra de arrastre solo es visible y funcional si activeSidebarView === 'results' y si el filtro específico de Precio (isPriceFilterOpen) está cerrado.  


Consistencia en Filtro de Precio: Se integró la variable isPriceFilterOpen en las validaciones de layout, ya que este filtro se maneja de forma independiente al resto de las vistas del sidebar.