### PR TITLE
fix: Bloqueo de acciones secundarias en Inmuebles al activar Comparación

### DIFF
--- a/frontend/src/components/galeria/ActionButton.tsx
+++ b/frontend/src/components/galeria/ActionButton.tsx
@@ -5,24 +5,37 @@ import { Eye } from 'lucide-react'
 interface ActionButtonProps {
   variant?: 'grid' | 'table'
   label?: string
+  disabled?: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 export default function ActionButton({
   variant = 'grid',
   label = 'Ver detalles',
+  disabled = false,
   onClick
 }: ActionButtonProps) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (disabled) {
+      e.preventDefault()
+      e.stopPropagation()
+      return
+    }
+    onClick(e)
+  }
   // --- VISTA TABLA ---
   if (variant === 'table') {
     return (
       <button
         type="button"
-        onClick={onClick}
-        title="Ver detalles"
-        className="hover:scale-110 transition-transform duration-200"
+        onClick={handleClick}
+        disabled={disabled}
+        title={disabled ? 'No disponible en este modo' : 'Ver detalles'}
+        className={`transition-transform duration-200 ${
+          disabled ? 'opacity-40 cursor-not-allowed' : 'hover:scale-110 cursor-pointer'
+        }`}
       >
-        <Eye className="w-4 h-4 text-[#E68B25] cursor-pointer" />
+        <Eye className="w-4 h-4 text-[#E68B25]" />
       </button>
     )
   }
@@ -31,9 +44,14 @@ export default function ActionButton({
   return (
     <button
       type="button"
-      onClick={onClick}
-      className="flex items-center justify-center w-full py-2.5 px-4 text-sm gap-2 rounded-lg font-medium transition-all duration-200 text-white shadow-sm bg-[#E68B25] hover:bg-amber-700"
-      title="Ver detalles"
+      onClick={handleClick}
+      disabled={disabled}
+      className={`flex items-center justify-center w-full py-2.5 px-4 text-sm gap-2 rounded-lg font-medium transition-all duration-200 ${
+        disabled
+          ? 'bg-stone-200 text-stone-400 cursor-not-allowed shadow-none'
+          : 'text-white shadow-sm bg-[#E68B25] hover:bg-amber-700'
+      }`}
+      title={disabled ? 'No disponible en este modo' : 'Ver detalles'}
     >
       <Eye className="w-5 h-5" />
       <span>{label}</span>

--- a/frontend/src/components/galeria/ComoLlegarButton.tsx
+++ b/frontend/src/components/galeria/ComoLlegarButton.tsx
@@ -6,16 +6,19 @@ interface ComoLlegarButtonProps {
   lat?: number | null
   lng?: number | null
   variant?: 'grid' | 'table'
+  disabled?: boolean
 }
-export default function ComoLlegarButton({ lat, lng, variant = 'grid' }: ComoLlegarButtonProps) {
+export default function ComoLlegarButton({ lat, lng, variant = 'grid', disabled = false }: ComoLlegarButtonProps) {
   const { openMap } = useMapRedirect()
   const isRedirecting = useRef(false)
   // #69 - Coordenadas validadas en rango geografico valido
   const hasLocation =
     lat != null && lng != null && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180
+  // Combinamos la lógica: está deshabilitado si no hay ubicación o si se pasa por prop (modo comparar)
+  const isButtonDisabled = !hasLocation || disabled
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
-    if (!hasLocation || isRedirecting.current) return
+    if (!hasLocation || isRedirecting.current || isButtonDisabled) return
     isRedirecting.current = true
     openMap(lat!, lng!)
     setTimeout(() => {
@@ -27,7 +30,7 @@ export default function ComoLlegarButton({ lat, lng, variant = 'grid' }: ComoLle
       <button
         type="button"
         onClick={handleClick}
-        disabled={!hasLocation}
+        disabled={isButtonDisabled}
         title={hasLocation ? '¿Cómo llegar?' : 'Ubicación no disponible'}
         aria-label="Calcular ruta hacia la propiedad en el mapa"
         data-testid="como-llegar-btn"
@@ -51,7 +54,7 @@ export default function ComoLlegarButton({ lat, lng, variant = 'grid' }: ComoLle
       <button
         type="button"
         onClick={handleClick}
-        disabled={!hasLocation}
+        disabled={isButtonDisabled}
         aria-label="Calcular ruta hacia la propiedad en el mapa"
         data-testid="como-llegar-btn"
         title={hasLocation ? '¿Cómo llegar?' : 'Ubicación no disponible'}

--- a/frontend/src/components/galeria/ContactButton.tsx
+++ b/frontend/src/components/galeria/ContactButton.tsx
@@ -1,25 +1,33 @@
 'use client'
 
 import { MessageCircle, MessageSquare } from 'lucide-react'
+import { JSX } from 'react'
 
 interface ContactButtonProps {
-  type: string // Puede ser 'whatsapp' o 'messenger'
+  type: 'whatsapp' | 'messenger'
   phoneNumber?: string
   variant?: 'grid' | 'table'
+  disabled?: boolean
 }
 
 export default function ContactButton({
   type,
   phoneNumber = '59170000000',
-  variant = 'grid'
-}: ContactButtonProps) {
+  variant = 'grid',
+  disabled = false
+}: ContactButtonProps): JSX.Element {
   const isWhatsApp = type === 'whatsapp'
 
-  // Lógica principal (Tu tarea T7)
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // Si está deshabilitado, evitamos el comportamiento por defecto y detenemos la propagación
+    if (disabled) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+    }
     const url = isWhatsApp
       ? `https://wa.me/${phoneNumber}?text=Hola,%20estoy%20interesado%20en%20esta%20propiedad`
-      : `https://m.me/tu_pagina_facebook` // Ejemplo para Messenger
+      : `https://m.me/tu_pagina_facebook`
     window.open(url, '_blank')
   }
 
@@ -28,24 +36,28 @@ export default function ContactButton({
     return (
       <button
         onClick={handleClick}
+        disabled={disabled}
         title={isWhatsApp ? 'Contactar por WhatsApp' : 'Contactar por Messenger'}
-        className="hover:scale-110 transition-transform duration-200"
+        className={`transition-transform duration-200 ${disabled ? 'opacity-40 cursor-not-allowed' : 'hover:scale-110 cursor-pointer'}`}
       >
         {isWhatsApp ? (
-          <MessageCircle className="w-4 h-4 text-green-500 cursor-pointer" />
+          <MessageCircle className="w-4 h-4 text-green-500" />
         ) : (
-          <MessageSquare className="w-4 h-4 text-blue-500 cursor-pointer" />
+          <MessageSquare className="w-4 h-4 text-blue-500" />
         )}
       </button>
     )
   }
 
-  // --- VISTA GRILLA (El botón grande y bonito que espera el Dev 3) ---
+  // --- VISTA GRILLA ---
   return (
     <button
       onClick={handleClick}
-      className={`flex items-center justify-center w-full py-2.5 px-4 text-sm gap-2 rounded-lg font-medium transition-all duration-200 text-white shadow-sm ${
-        isWhatsApp ? 'bg-[#25D366] hover:bg-[#20ba5a]' : 'bg-[#0084FF] hover:bg-[#0073e6]'
+      disabled={disabled}
+      className={`flex items-center justify-center w-full py-2.5 px-4 text-sm gap-2 rounded-lg font-medium transition-all duration-200 shadow-sm ${
+        disabled 
+            ? 'bg-stone-200 text-stone-400 cursor-not-allowed shadow-none' 
+            : `text-white ${isWhatsApp ? 'bg-[#25D366] hover:bg-[#20ba5a]' : 'bg-[#0084FF] hover:bg-[#0073e6]'}`
       }`}
       title={isWhatsApp ? 'Contactar por WhatsApp' : 'Contactar por Messenger'}
     >

--- a/frontend/src/components/galeria/PropertyRow.tsx
+++ b/frontend/src/components/galeria/PropertyRow.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { normalizePropertyThumbnailUrl } from '@/lib/propertyThumbnailUrl'
 import ComoLlegarButton from './ComoLlegarButton'
 import { MapPin } from 'lucide-react'
+import { useCompareStore } from '@/hooks/useCompareStore'
 
 export default function PropertyRow({
   title,
@@ -32,6 +33,7 @@ export default function PropertyRow({
   onViewDetails?: () => void
 }) {
   const [isHovered, setIsHovered] = useState(false)
+  const { isCompareMode } = useCompareStore() // Obtenemos el estado de comparación para deshabilitar botones si es necesario
   const imageSrc = normalizePropertyThumbnailUrl(
     image,
     'https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?auto=format&fit=crop&w=800&q=80'
@@ -87,6 +89,7 @@ export default function PropertyRow({
       <div className="flex justify-center">
         <ActionButton
           variant="table"
+          disabled={isCompareMode}
           onClick={(event) => {
             // HU4 - Evita disparar el click general de la tabla al hacer click en el botón de detalles
             event.stopPropagation()
@@ -98,10 +101,14 @@ export default function PropertyRow({
       {/* CONTACTO: Aquí entra tu magia limpia y modular */}
       {/* HU13 #70 - Boton Como llegar modo lista con lat/lng como props */}
       <div className="flex justify-center min-h-[44px] items-center" role="navigation" aria-label="Navegar a ubicacion de la propiedad">
-        <ComoLlegarButton lat={lat} lng={lng} variant="table" data-testid="como-llegar-row" />
+        <ComoLlegarButton lat={lat} lng={lng} variant="table" disabled={isCompareMode} data-testid="como-llegar-row" /> {/* Bloqueamos si compara */}
       </div>
       <div className="flex justify-center">
-        <ContactButton type={contactType} variant="table" />
+        <ContactButton 
+          type={contactType as "whatsapp" | "messenger"} 
+          variant="table" 
+          disabled={isCompareMode} 
+        />
       </div>
     </div>
   )

--- a/frontend/src/components/layout/PropertyCard.tsx
+++ b/frontend/src/components/layout/PropertyCard.tsx
@@ -6,6 +6,7 @@ import ContactButton from '../galeria/ContactButton' // <-- Tu botón modular im
 import ActionButton from '../galeria/ActionButton' // <-- Botón de ver detalles (opcional, lo puedes usar o no dependiendo de tu diseño)
 import { useState } from 'react'
 import ComoLlegarButton from '../galeria/ComoLlegarButton'
+import { useCompareStore } from '@/hooks/useCompareStore'
 
 type PropsTarjeta = {
   imagen?: string
@@ -54,6 +55,9 @@ export default function PropertyCard({
   precio_anterior
 }: PropsTarjeta) {
   const [isHovered, setIsHovered] = useState(false)
+
+  // Obtenemos el estado isCompareMode
+  const { isCompareMode } = useCompareStore()
 
   // Calcular oferta HU6
   const precioNum = Number(precio)
@@ -175,11 +179,11 @@ export default function PropertyCard({
 
         {/* 3. Botón de contacto modular */}
         <div className="mt-1 w-full min-h-[44px] flex items-center">
-          <ContactButton type="whatsapp" variant="grid" />
+          <ContactButton type="whatsapp" variant="grid" disabled={isCompareMode} />
         </div>
         {/* HU13 #68 #69 - Botón ¿Cómo llegar? visible sin scroll horizontal, con estado deshabilitado y tooltip */}
         <div className="mt-1 w-full min-h-[44px] flex items-center">
-          <ComoLlegarButton lat={lat} lng={lng} variant="grid" />
+          <ComoLlegarButton lat={lat} lng={lng} variant="grid" disabled={isCompareMode} />
         </div>
 
         {/* 4. Botón de ver detalles (HU4 - Nuevo botón para abrir el detalle en una nueva pestaña) */}
@@ -187,6 +191,8 @@ export default function PropertyCard({
           <ActionButton
             variant="grid"
             label="Ver detalles"
+            // Deshabilitamos ActionButton si está en modo comparación
+            disabled={isCompareMode}
             onClick={(event) => {
               // HU4 - Evita disparar el click general del card
               event.stopPropagation()


### PR DESCRIPTION
Cambios principales:

PropertyCard.tsx: Ahora consume el estado isCompareMode del store de comparación y propaga una propiedad disabled a todos sus botones hijos.

Refactorización de Botones Modulares:

Se actualizaron ContactButton, ComoLlegarButton y ActionButton para soportar la propiedad disabled.

Se mejoró el tipado en ContactButton para asegurar el retorno de JSX.Element y evitar errores de compilación.

Feedback Visual: Cuando la comparación está activa, los botones cambian a un color gris (bg-stone-200) y el cursor se transforma en not-allowed, indicando claramente que la interacción está pausada.

Seguridad de Eventos: Se agregaron validaciones en los manejadores de clic para detener la propagación y prevenir ejecuciones de funciones (como abrir WhatsApp o el mapa) si el botón está bloqueado.