### PR TITLE
fix: limpiar propiedades al cambiar ubicacion BUG1

### DIFF
--- a/frontend/src/hooks/useProperties.ts
+++ b/frontend/src/hooks/useProperties.ts
@@ -356,6 +356,8 @@ export function useProperties(): UsePropertiesResult {
     }
 
     async function fetchProperties() {
+       setIsLoading(true)   // ← AGREGAR
+       setProperties([]) 
       setError(null)
 
       // ✅ Modo recomendados (persistente por URL)


### PR DESCRIPTION
Anteriormente, al interactuar con el sistema de filtros y cambiar la ubicación, el listado de propiedades no se limpiaba correctamente. Esto mantenía en pantalla datos previos que ya no correspondían a la nueva búsqueda.

#Archivos modificados
frontend/src/hooks/useProperties.ts