### PR TITLE
fix(blog): limitar comentario de rechazo a 500 caracteres

### DIFF
--- a/backend/src/modules/blogs/blogs.controller.ts
+++ b/backend/src/modules/blogs/blogs.controller.ts
@@ -238,6 +238,10 @@ export const cambiarEstadoBlog = async (req: AuthRequest, res: Response) => {
         return res
           .status(400)
           .json({ message: "Debes proporcionar una razón de rechazo" });
+      if (error.message === "RAZON_RECHAZO_TOO_LONG")
+        return res
+          .status(400)
+          .json({ message: "El comentario de rechazo no puede superar los 500 caracteres" });
     }
     return handleError(res, error);
   }

--- a/backend/src/modules/blogs/blogs.service.ts
+++ b/backend/src/modules/blogs/blogs.service.ts
@@ -144,6 +144,9 @@ export const blogsService = {
     if (estado === "RECHAZADO" && !razon_rechazo) {
       throw new Error("RAZON_RECHAZO_REQUIRED");
     }
+    if (razon_rechazo && razon_rechazo.length > 500) {
+      throw new Error("RAZON_RECHAZO_TOO_LONG");
+    }
 
     const updatedBlog = await blogsRepository.changeEstado(
       id,

--- a/frontend/src/app/mis-blogs/page.tsx
+++ b/frontend/src/app/mis-blogs/page.tsx
@@ -229,7 +229,7 @@ export default function MisBlogsPage() {
                   {blog.estado === "RECHAZADO" && blog.blog_rechazo && blog.blog_rechazo.length > 0 && (
                     <div className="mb-4 p-3 bg-[#FDECEC] border border-[#F3BABA] rounded-lg">
                       <p className="text-xs font-bold text-[#D94848] uppercase tracking-wider mb-1">Motivo de rechazo:</p>
-                      <p className="text-sm text-[#D94848]">{blog.blog_rechazo[0].comentario}</p>
+                      <p className="text-sm text-[#D94848] break-words">{blog.blog_rechazo[0].comentario}</p>
                     </div>
                   )}
 

--- a/frontend/src/components/blog/BlogCreateForm.tsx
+++ b/frontend/src/components/blog/BlogCreateForm.tsx
@@ -110,7 +110,7 @@ export default function BlogCreateForm({
           {statusLabel === "RECHAZADO" && rejectionReason && (
             <div className="rounded-[24px] bg-[#FDECEC] border border-[#F3BABA] p-6 shadow-sm">
               <h3 className="text-sm font-bold text-[#D94848] uppercase tracking-wider mb-2">Motivo de rechazo</h3>
-              <p className="text-[#D94848] leading-relaxed">{rejectionReason}</p>
+              <p className="text-[#D94848] leading-relaxed break-words">{rejectionReason}</p>
               <p className="text-xs text-[#D94848]/80 mt-3 italic">Corrige los puntos mencionados y vuelve a enviarlo para revisión.</p>
             </div>
           )}

--- a/frontend/src/components/blog/admin/AdminBlogReview.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogReview.tsx
@@ -227,9 +227,13 @@ export default function AdminBlogReview({ blogId }: { blogId: string }) {
                       setFormError("");
                     }}
                     rows={5}
+                    maxLength={500}
                     placeholder="Ejemplo: falta citar fuentes, mejorar estructura o corregir tono editorial."
                     className="w-full rounded-2xl border border-stone-300 px-5 py-4 text-sm text-stone-700 outline-none transition focus:border-amber-600"
                   />
+                  <p className={`mt-1 text-right text-xs ${rejectionComment.length >= 450 ? "text-red-500" : "text-stone-400"}`}>
+                    {rejectionComment.length}/500 caracteres
+                  </p>
                 </label>
 
                 {formError && (


### PR DESCRIPTION
Cambios
- maxLength={500} en textarea del admin + contador visual
- Validación server-side en blogs.service.ts
- Manejo de error HTTP 400 en blogs.controller.ts
- break-words en BlogCreateForm.tsx y mis-blogs/page.tsx
