### PR TITLE
fix(blog): corregi texto de publicación invisible en modo oscuro con …

### DIFF
--- a/frontend/src/components/blog/BlogCreateForm.tsx
+++ b/frontend/src/components/blog/BlogCreateForm.tsx
@@ -108,10 +108,10 @@ export default function BlogCreateForm({
           )}
 
           {statusLabel === "RECHAZADO" && rejectionReason && (
-            <div className="rounded-2xl bg-red-50 border border-red-200 p-4 sm:p-6 shadow-sm">
-              <h3 className="text-sm font-bold text-red-700 uppercase tracking-wider mb-2">Motivo de rechazo</h3>
-              <p className="text-red-700 leading-relaxed break-all">{rejectionReason}</p>
-              <p className="text-xs text-red-600 mt-3 italic opacity-80">Corrige los puntos mencionados y vuelve a enviarlo para revisión.</p>
+            <div className="rounded-[16px] bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800/50 p-4 sm:p-6 shadow-sm">
+              <h3 className="text-sm font-bold text-red-700 dark:!text-red-400 uppercase tracking-wider mb-2">Motivo de rechazo</h3>
+              <p className="text-red-700 dark:!text-red-300 leading-relaxed break-all">{rejectionReason}</p>
+              <p className="text-xs text-red-600 dark:!text-red-400 mt-3 italic opacity-80">Corrige los puntos mencionados y vuelve a enviarlo para revisión.</p>
             </div>
           )}
 

--- a/frontend/src/components/blog/form/BlogSidebar.tsx
+++ b/frontend/src/components/blog/form/BlogSidebar.tsx
@@ -50,9 +50,9 @@ export default function BlogSidebar({
         <div className="flex items-center justify-between pt-2">
           <span className="text-sm font-medium text-[#78716C] dark:text-[#999]">Estado</span>
           <span className={`inline-flex items-center rounded-lg px-3 py-1 text-[10px] font-bold ${
-            isPendiente ? "bg-amber-100 text-amber-700" :
-            isRechazado ? "bg-red-100 text-red-600" :
-            statusLabel === "PUBLICADO" ? "bg-green-100 text-green-700" :
+            isPendiente ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:!text-amber-300" :
+            isRechazado ? "bg-red-100 text-red-600 dark:bg-red-900/30 dark:!text-red-300" :
+            statusLabel === "PUBLICADO" ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:!text-green-300" :
             "bg-[#E7E5E4] text-[#44403C] dark:text-[#999]"
           }`}>
             {statusLabel ?? "BORRADOR"}


### PR DESCRIPTION
Cambios realizados
Se añadió min-w-0 overflow-hidden al contenedor principal del grid para evitar que el texto largo desborde y rompa el layout (BlogCreateForm.tsx)
Se cambió break-words por break-all en el párrafo del motivo de rechazo, permitiendo que palabras o URLs muy largas se corten correctamente
Se añadió hidden lg:block a la sección de guías del sidebar para evitar que se muestre en móvil y rompa el diseño (BlogSidebar.tsx)
Ajuste de padding responsivo en el sidebar (p-4 sm:p-6)