### PR TITLE
fix: Persistencia de estado en Modo Comparar tras reload

### DIFF
--- a/frontend/src/hooks/useCompareStore.ts
+++ b/frontend/src/hooks/useCompareStore.ts
@@ -43,7 +43,11 @@ export const useCompareStore = create<CompareState>()(
     }),
     {
       name: 'propbol-compare-storage',
-      partialize: (state) => ({ selectedIds: state.selectedIds }), // Solo persistimos los IDs
+      // FIX: Ahora persistimos tanto los IDs como el estado visual del modo comparar
+      partialize: (state) => ({ 
+        selectedIds: state.selectedIds,
+        isCompareMode: state.isCompareMode 
+      }), 
     }
   )
 )


### PR DESCRIPTION
Descripción:
Resolución de Bug: BUG-07-01
El sistema perdía la visualización del estado del comparador al actualizar el navegador (F5), rompiendo la experiencia de usuario y aparentando pérdida de datos.

Causa Raíz:
El middleware persist de Zustand estaba configurado (partialize) para guardar en el LocalStorage únicamente el array selectedIds, omitiendo el booleano isCompareMode. Al rehidratar el estado tras un refresh, el modo comparar volvía a su valor por defecto (false), ocultando la UI.

Solución Implementada:

useCompareStore.ts: Se actualizó el retorno del método partialize para incluir explícitamente isCompareMode: state.isCompareMode.

Impacto:

Cumplimiento del criterio de aceptación: La sesión del comparador (IDs seleccionados + UI activa) ahora sobrevive a recargas accidentales o intencionales de la página, especialmente útil en navegadores móviles donde el reload al hacer scroll hacia arriba es común.