### PR TITLE
Hotfix/blogs

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -562,6 +562,13 @@ html.dark body :where(h1,
   color: var(--pb-text) !important;
 }
 
+/* Logo header: solo "Bol" en naranja */
+html.dark body #tour-logo .propbol-logo-bol,
+html.dark body a[id="tour-logo"] .propbol-logo-bol,
+.propbol-logo-bol {
+  color: #e68b25 !important;
+}
+
 /* Textos secundarios */
 html.dark body :where(small,
   input::placeholder,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -598,7 +598,7 @@ html.dark body :where([class*="shadow"],
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.75) !important;
 }
 
-/* Botones principales naranjas */
+/* Botones principales naranjas (excluye variantes con opacidad, ej. hover:bg-[#E68B25]/10) */
 html.dark body :where([class*="bg-amber-500"],
   [class*="bg-amber-600"],
   [class*="bg-orange-500"],
@@ -606,7 +606,7 @@ html.dark body :where([class*="bg-amber-500"],
   [class*="bg-[#E68B25]"],
   [class*="bg-[#e68b25]"],
   [class*="bg-[#E8962F]"],
-  [class*="bg-[#e8962f]"]) {
+  [class*="bg-[#e8962f]"]):not([class*="/"]) {
   background: var(--pb-accent) !important;
   color: #ffffff !important;
   border-color: var(--pb-accent) !important;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -467,9 +467,9 @@ html.dark body :where([class*="bg-white"],
   [class*="bg-stone"],
   [class*="bg-card"],
   [class*="bg-muted"],
-  [class*="bg-amber-50"],
+  [class*="bg-amber-50"]:not([class*="bg-amber-5"]):not([class*="bg-amber-6"]):not([class*="bg-amber-7"]),
   [class*="bg-yellow-50"],
-  [class*="bg-orange-50"],
+  [class*="bg-orange-50"]:not([class*="bg-orange-5"]):not([class*="bg-orange-6"]),
   [class*="bg-[#0"],
   [class*="bg-[#1"],
   [class*="bg-[#2"],
@@ -484,7 +484,7 @@ html.dark body :where([class*="bg-white"],
   [class*="bg-[#f5"],
   [class*="bg-[#F5"],
   [class*="bg-[#f8"],
-  [class*="bg-[#F8"]):not([class*="/"]) {
+  [class*="bg-[#F8"]):not([class*="/"]):not([class*="bg-[#D97706]"]):not([class*="bg-[#d97706]"]) {
   background: var(--pb-surface) !important;
   background-image: none !important;
   color: var(--pb-text) !important;
@@ -603,10 +603,14 @@ html.dark body :where([class*="bg-amber-500"],
   [class*="bg-amber-600"],
   [class*="bg-orange-500"],
   [class*="bg-orange-600"],
+  [class*="bg-[#D97706]"],
+  [class*="bg-[#d97706]"],
   [class*="bg-[#E68B25]"],
   [class*="bg-[#e68b25]"],
   [class*="bg-[#E8962F]"],
-  [class*="bg-[#e8962f]"]):not([class*="/"]) {
+  [class*="bg-[#e8962f]"],
+  [class*="bg-[#E87C1E]"],
+  [class*="bg-[#e87c1e]"]):not([class*="/"]) {
   background: var(--pb-accent) !important;
   color: #ffffff !important;
   border-color: var(--pb-accent) !important;
@@ -626,9 +630,9 @@ html.dark body button:disabled {
   opacity: 0.8 !important;
 }
 
-/* panel superior de mis publicaciones */
-html.dark .rounded-2xl,
-html.dark .rounded-xl,
+/* panel superior de mis publicaciones (no aplica a botones/enlaces naranjas) */
+html.dark .rounded-2xl:not([class*="bg-amber"]):not([class*="bg-orange"]):not([class*="bg-[#E68B25]"]):not([class*="bg-[#e68b25]"]):not([class*="bg-[#D97706]"]):not([class*="bg-[#d97706]"]),
+html.dark .rounded-xl:not([class*="bg-amber"]):not([class*="bg-orange"]):not([class*="bg-[#E68B25]"]):not([class*="bg-[#e68b25]"]):not([class*="bg-[#D97706]"]):not([class*="bg-[#d97706]"]),
 html.dark [class*="from-white"],
 html.dark [class*="from-gray"],
 html.dark [class*="to-white"],
@@ -637,6 +641,26 @@ html.dark [class*="to-gray"] {
   background-image: none !important;
   color: #ffffff !important;
   border-color: #222222 !important;
+}
+
+/* Botones naranjas con rounded (prioridad sobre regla de cards) */
+html.dark body :where(
+  button[class*="bg-amber-5"],
+  button[class*="bg-amber-6"],
+  button[class*="bg-amber-7"],
+  button[class*="bg-orange-5"],
+  button[class*="bg-orange-6"],
+  a[class*="bg-amber-5"],
+  a[class*="bg-amber-6"],
+  a[class*="bg-orange-5"],
+  a[class*="bg-orange-6"],
+  a[class*="bg-[#D97706]"],
+  a[class*="bg-[#d97706]"],
+  a[class*="bg-[#E68B25]"],
+  a[class*="bg-[#e68b25]"]):not([class*="/"]) {
+  background: var(--pb-accent) !important;
+  color: #ffffff !important;
+  border-color: var(--pb-accent) !important;
 }
 
 /* Botón principal del popup de bienvenida/login */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -600,9 +600,21 @@ html.dark body :where([class*="border-gray"],
   --tw-ring-shadow: 0 0 #0000 !important;
 }
 
-html.dark body :where([class*="shadow"],
-  [class*="drop-shadow"]) {
+/* Solo box-shadow (cards); no drop-shadow (filtro de texto en banner, etc.) */
+html.dark body :where([class*="shadow"]):not([class*="drop-shadow"]) {
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.75) !important;
+}
+
+/* Banner home: texto sobre imagen sin fondo ni sombra de caja */
+html.dark #tour-banner h1,
+html.dark #tour-banner p {
+  background: transparent !important;
+  box-shadow: none !important;
+  color: #ffffff !important;
+}
+
+html.dark #tour-banner p {
+  color: #e7e5e4 !important;
 }
 
 /* Botones principales naranjas (excluye variantes con opacidad, ej. hover:bg-[#E68B25]/10) */

--- a/frontend/src/components/blog/BlogCard.tsx
+++ b/frontend/src/components/blog/BlogCard.tsx
@@ -61,7 +61,7 @@ export default function BlogCard({
         <div className="flex flex-1 flex-col p-6 sm:p-8">
           {/* Categoría Pill */}
           <div className="mb-4">
-            <span className="inline-block rounded-full border border-[#D97706]/20 bg-[#D97706]/5 px-4 py-1 text-[10px] font-bold uppercase tracking-widest text-[#D97706] dark:text-[#D97706]/80">  /* Cambia el color del texto para modo oscuro */
+            <span className="inline-block rounded-full border border-[#D97706]/20 bg-[#D97706]/5 px-4 py-1 text-[10px] font-bold uppercase tracking-widest text-[#D97706] dark:text-[#D97706]/80">
               {categoryLabel ?? category}
             </span>
           </div>

--- a/frontend/src/components/navbar/Logo.tsx
+++ b/frontend/src/components/navbar/Logo.tsx
@@ -58,9 +58,9 @@ export default function Logo({
     >
       <LogoMark className={iconClassName} size={iconSize} />
       <span
-        className={`font-heading text-[1.2rem] font-bold leading-none tracking-[-0.03em] text-stone-900 ${textClassName}`}
+        className={`font-heading text-[1.2rem] font-bold leading-none tracking-[-0.03em] text-stone-900 dark:text-white ${textClassName}`}
       >
-        Prop<span className="text-amber-600">Bol</span>
+        Prop<span className="propbol-logo-bol">Bol</span>
       </span>
     </Link>
   )


### PR DESCRIPTION
Cambios incluidos
1. Blog — etiqueta de categoría (BlogCard.tsx)
Se eliminó un comentario CSS (/* Cambia el color del texto para modo oscuro */) que se renderizaba como texto visible en las tarjetas de blog.
2. Header — navegación (globals.css)
Los enlaces del navbar (hover:bg-[#E68B25]/10) dejaban de verse como texto y pasaban a parecer botones naranjas.
Solución: excluir clases con opacidad (:not([class*="/"])) de la regla que fuerza fondo naranja en botones.
3. Home — botones naranjas (globals.css)
Explorar Blogs, Ver propiedades y otros CTAs perdían el color naranja en modo oscuro.
Causas:
bg-[#D97706] coincidía con el selector bg-[#D].
bg-amber-50 coincidía con bg-amber-500.
.rounded-xl forzaba fondo negro sobre botones redondeados.
Solución: exclusiones en reglas de conversión a oscuro, ampliación de colores de marca preservados y regla específica para botones/enlaces naranjas con rounded.
4. Logo — solo “Bol” en naranja (Logo.tsx + globals.css)
Clase dedicada propbol-logo-bol para teñir solo Bol de naranja (#e68b25).
Prop queda negro en claro y blanco en oscuro, sin afectar otros textos del sitio.
5. Banner — texto del carrusel (globals.css)
Títulos y subtítulos mostraban una franja oscura (“subrayado”) detrás de las letras.
Causa: la regla global convertía drop-shadow (filtro de texto) en box-shadow (sombra de caja).
Solución: excluir drop-shadow de la regla de sombras y proteger #tour-banner para texto limpio sobre la imagen.