### PR TITLE
fix(filtros): BUG OR en etiquetas múltiples + conteo contextual según filtros activos

### DIFF
--- a/backend/src/modules/properties/properties.repository.ts
+++ b/backend/src/modules/properties/properties.repository.ts
@@ -286,23 +286,16 @@ export const propertiesRepository = {
       ];
     }
 
-    // Filtros por Etiquetas (Lógica AND)
+    // Filtros por Etiquetas (Lógica OR)
     if (filtros.labels && filtros.labels.length > 0) {
-      where.AND = [
-        ...(where.AND || []),
-        ...filtros.labels.map((labelId) => ({
-          publicaciones: {
-            some: {
-              estado: 'ACTIVA' as const,
-              publicacion_tag: {
-                some: {
-                  tag_id: labelId
-                }
-              }
-            }
+      where.publicaciones = {
+        some: {
+          estado: 'ACTIVA' as const,
+          publicacion_tag: {
+            some: { tag_id: { in: filtros.labels } }
           }
-        }))
-      ]
+        }
+      }
     }
 
     // HU6 - Filtro solo ofertas

--- a/backend/src/modules/tags/tags.controller.ts
+++ b/backend/src/modules/tags/tags.controller.ts
@@ -1,105 +1,127 @@
-import type { Request, Response } from "express";
-import { validationResult } from "express-validator";
-import { tagsService } from "./tags.service.js";
+import type { Request, Response } from 'express'
+import { validationResult } from 'express-validator'
+import { tagsService } from './tags.service.js'
 
 export const getTagsController = async (_req: Request, res: Response) => {
   try {
-    const data = await tagsService.getAll();
-    return res.status(200).json({ ok: true, data });
+    const data = await tagsService.getAll()
+    return res.status(200).json({ ok: true, data })
   } catch (error) {
-    console.error("Error al listar tags:", error);
+    console.error('Error al listar tags:', error)
     return res.status(500).json({
       ok: false,
-      message: "INTERNAL_SERVER_ERROR",
-      mensaje: "Error al listar tags",
-    });
+      message: 'INTERNAL_SERVER_ERROR',
+      mensaje: 'Error al listar tags'
+    })
   }
-};
+}
 
-export const getTagsByPublicacionController = async (
-  req: Request,
-  res: Response,
-) => {
+export const getTagsWithCountsController = async (req: Request, res: Response) => {
   try {
-    const publicacionId = Number(req.params.publicacionId);
-    const data = await tagsService.getTagsByPublicacion(publicacionId);
-    return res.status(200).json({ ok: true, data });
+    const data = await tagsService.getTagsWithCounts({
+      tipoInmueble: req.query.tipoInmueble as string | undefined,
+      modoInmueble: req.query.modoInmueble as string | undefined,
+      minPrice: req.query.minPrice ? Number(req.query.minPrice) : null,
+      maxPrice: req.query.maxPrice ? Number(req.query.maxPrice) : null,
+      currency: req.query.currency as string | undefined,
+      minSuperficie: req.query.minSuperficie ? Number(req.query.minSuperficie) : null,
+      maxSuperficie: req.query.maxSuperficie ? Number(req.query.maxSuperficie) : null,
+      dormitoriosMin: req.query.dormitoriosMin ? Number(req.query.dormitoriosMin) : undefined,
+      dormitoriosMax: req.query.dormitoriosMax ? Number(req.query.dormitoriosMax) : undefined,
+      banosMin: req.query.banosMin ? Number(req.query.banosMin) : undefined,
+      banosMax: req.query.banosMax ? Number(req.query.banosMax) : undefined,
+      departamentoId: req.query.departamentoId as string | undefined,
+      provinciaId: req.query.provinciaId as string | undefined,
+      municipioId: req.query.municipioId as string | undefined,
+      zonaId: req.query.zonaId as string | undefined,
+      barrioId: req.query.barrioId as string | undefined
+    })
+
+    return res.status(200).json({ ok: true, data })
   } catch (error) {
-    console.error("Error al listar tags de la publicación:", error);
+    console.error('Error al listar tags con conteo contextual:', error)
     return res.status(500).json({
       ok: false,
-      message: "INTERNAL_SERVER_ERROR",
-      mensaje: "Error al listar tags de la publicación",
-    });
+      message: 'INTERNAL_SERVER_ERROR',
+      mensaje: 'Error al listar tags con conteo contextual'
+    })
   }
-};
+}
 
-export const replacePublicacionTagsController = async (
-  req: Request,
-  res: Response,
-) => {
-  const errors = validationResult(req);
+export const getTagsByPublicacionController = async (req: Request, res: Response) => {
+  try {
+    const publicacionId = Number(req.params.publicacionId)
+    const data = await tagsService.getTagsByPublicacion(publicacionId)
+    return res.status(200).json({ ok: true, data })
+  } catch (error) {
+    console.error('Error al listar tags de la publicación:', error)
+    return res.status(500).json({
+      ok: false,
+      message: 'INTERNAL_SERVER_ERROR',
+      mensaje: 'Error al listar tags de la publicación'
+    })
+  }
+}
+
+export const replacePublicacionTagsController = async (req: Request, res: Response) => {
+  const errors = validationResult(req)
   if (!errors.isEmpty()) {
     return res.status(400).json({
       ok: false,
       errores: errors.array().map((e) => ({
-        campo: "path" in e ? e.path : "general",
-        mensaje: e.msg,
-      })),
-    });
+        campo: 'path' in e ? e.path : 'general',
+        mensaje: e.msg
+      }))
+    })
   }
 
   if (!req.user?.id) {
     return res.status(401).json({
       ok: false,
-      message: "NOT_AUTHENTICATED",
-      mensaje: "Usuario no autenticado",
-    });
+      message: 'NOT_AUTHENTICATED',
+      mensaje: 'Usuario no autenticado'
+    })
   }
 
   try {
-    const publicacionId = Number(req.params.publicacionId);
-    const { tags } = req.body;
+    const publicacionId = Number(req.params.publicacionId)
+    const { tags } = req.body
 
-    const data = await tagsService.replacePublicacionTags(
-      publicacionId,
-      req.user.id,
-      tags ?? [],
-    );
+    const data = await tagsService.replacePublicacionTags(publicacionId, req.user.id, tags ?? [])
 
     return res.status(200).json({
       ok: true,
-      mensaje: "Tags actualizados correctamente",
-      data,
-    });
+      mensaje: 'Tags actualizados correctamente',
+      data
+    })
   } catch (error) {
-    if (error instanceof Error && error.message === "PUBLICATION_NOT_FOUND") {
+    if (error instanceof Error && error.message === 'PUBLICATION_NOT_FOUND') {
       return res.status(404).json({
         ok: false,
-        message: "PUBLICATION_NOT_FOUND",
-        mensaje: "La publicación no existe",
-      });
+        message: 'PUBLICATION_NOT_FOUND',
+        mensaje: 'La publicación no existe'
+      })
     }
-    if (error instanceof Error && error.message === "FORBIDDEN") {
+    if (error instanceof Error && error.message === 'FORBIDDEN') {
       return res.status(403).json({
         ok: false,
-        message: "FORBIDDEN",
-        mensaje: "No tienes permiso para modificar esta publicación",
-      });
+        message: 'FORBIDDEN',
+        mensaje: 'No tienes permiso para modificar esta publicación'
+      })
     }
-    if (error instanceof Error && error.message === "MAX_TAGS_EXCEEDED") {
+    if (error instanceof Error && error.message === 'MAX_TAGS_EXCEEDED') {
       return res.status(400).json({
         ok: false,
-        message: "MAX_TAGS_EXCEEDED",
-        mensaje: "No puedes agregar más de 15 tags",
-      });
+        message: 'MAX_TAGS_EXCEEDED',
+        mensaje: 'No puedes agregar más de 15 tags'
+      })
     }
 
-    console.error("Error al actualizar tags:", error);
+    console.error('Error al actualizar tags:', error)
     return res.status(500).json({
       ok: false,
-      message: "INTERNAL_SERVER_ERROR",
-      mensaje: "Error al actualizar tags",
-    });
+      message: 'INTERNAL_SERVER_ERROR',
+      mensaje: 'Error al actualizar tags'
+    })
   }
-};
+}

--- a/backend/src/modules/tags/tags.repository.ts
+++ b/backend/src/modules/tags/tags.repository.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client'
 import { prisma } from '../../lib/prisma.client.js'
 
 const findAll = async () => {
@@ -9,6 +10,38 @@ const findAll = async () => {
     where: {
       publicacion: {
         estado: 'ACTIVA'
+      }
+    },
+    select: {
+      tag_id: true
+    }
+  })
+
+  const countMap = new Map<number, number>()
+
+  for (const row of publicacionesTags) {
+    const currentCount = countMap.get(row.tag_id) ?? 0
+    countMap.set(row.tag_id, currentCount + 1)
+  }
+
+  return tags.map((tag) => ({
+    id: tag.id,
+    nombre: tag.nombre,
+    creado_en: tag.creado_en,
+    cantidad: countMap.get(tag.id) ?? 0
+  }))
+}
+
+const findAllWithContextualCounts = async (inmuebleWhere: Prisma.InmuebleWhereInput) => {
+  const tags = await prisma.tag.findMany({
+    orderBy: { nombre: 'asc' }
+  })
+
+  const publicacionesTags = await prisma.publicacion_tag.findMany({
+    where: {
+      publicacion: {
+        estado: 'ACTIVA',
+        inmueble: inmuebleWhere
       }
     },
     select: {
@@ -91,6 +124,7 @@ const findPublicacionOwner = async (publicacionId: number) => {
 
 export const tagsRepository = {
   findAll,
+  findAllWithContextualCounts,
   findByName,
   findOrCreate,
   findByPublicacionId,

--- a/backend/src/modules/tags/tags.routes.ts
+++ b/backend/src/modules/tags/tags.routes.ts
@@ -3,19 +3,17 @@ import { requireAuth } from '../../middleware/auth.middleware.js'
 import {
   getTagsController,
   getTagsByPublicacionController,
-  replacePublicacionTagsController
+  replacePublicacionTagsController,
+  getTagsWithCountsController
 } from './tags.controller.js'
 import { replaceTagsRules } from './tags.validator.js'
 
 const router = Router()
 
-// Obtener todos los tags (para sugerencias)
 router.get('/', getTagsController)
-
-// Obtener tags de una publicación
+router.get('/counts', getTagsWithCountsController)
 router.get('/publicaciones/:publicacionId', getTagsByPublicacionController)
 
-// Reemplazar tags de una publicación
 router.put(
   '/publicaciones/:publicacionId',
   requireAuth,

--- a/backend/src/modules/tags/tags.service.ts
+++ b/backend/src/modules/tags/tags.service.ts
@@ -1,9 +1,140 @@
+import type { Prisma, Categoria, TipoAccion } from '@prisma/client'
 import { tagsRepository } from './tags.repository.js'
 
 const MAX_TAGS = 15
+const TASA_CAMBIO_BOB = 6.96
+
+type TagsContextFilters = {
+  tipoInmueble?: string
+  modoInmueble?: string
+  minPrice?: number | null
+  maxPrice?: number | null
+  currency?: string | null
+  minSuperficie?: number | null
+  maxSuperficie?: number | null
+  dormitoriosMin?: number
+  dormitoriosMax?: number
+  banosMin?: number
+  banosMax?: number
+  departamentoId?: string
+  provinciaId?: string
+  municipioId?: string
+  zonaId?: string
+  barrioId?: string
+}
+
+const CATEGORIAS_VALIDAS = [
+  'CASA',
+  'DEPARTAMENTO',
+  'TERRENO',
+  'OFICINA',
+  'CUARTO',
+  'TERRENO_MORTUORIO'
+] as const
+
+const MODOS_VALIDOS = ['VENTA', 'ALQUILER', 'ANTICRETO'] as const
+
+const esCategoriaValida = (valor: string): valor is Categoria => {
+  return (CATEGORIAS_VALIDAS as readonly string[]).includes(valor)
+}
+
+const esTipoAccionValido = (valor: string): valor is TipoAccion => {
+  return (MODOS_VALIDOS as readonly string[]).includes(valor)
+}
+
+const buildInmuebleWhereFromFilters = (filtros: TagsContextFilters): Prisma.InmuebleWhereInput => {
+  const where: Prisma.InmuebleWhereInput = {
+    estado: 'ACTIVO'
+  }
+
+  if (filtros.tipoInmueble && filtros.tipoInmueble !== 'CUALQUIER TIPO') {
+    const tipoNormalizado = filtros.tipoInmueble.toUpperCase().trim()
+    if (esCategoriaValida(tipoNormalizado)) {
+      where.categoria = tipoNormalizado
+    }
+  }
+
+  if (filtros.modoInmueble) {
+    const modoNormalizado = filtros.modoInmueble.toUpperCase().trim()
+    const modoFinal = modoNormalizado.includes('ANTICR') ? 'ANTICRETO' : modoNormalizado
+
+    if (esTipoAccionValido(modoFinal)) {
+      where.tipoAccion = modoFinal
+    }
+  }
+
+  let minPrice = filtros.minPrice ?? null
+  let maxPrice = filtros.maxPrice ?? null
+
+  if (filtros.currency && ['BOB', 'BS'].includes(filtros.currency.toUpperCase())) {
+    if (minPrice != null) minPrice = minPrice / TASA_CAMBIO_BOB
+    if (maxPrice != null) maxPrice = maxPrice / TASA_CAMBIO_BOB
+  }
+
+  if (minPrice != null || maxPrice != null) {
+    where.precio = {
+      ...(minPrice != null ? { gte: minPrice } : {}),
+      ...(maxPrice != null ? { lte: maxPrice } : {})
+    }
+  }
+
+  if (filtros.minSuperficie != null || filtros.maxSuperficie != null) {
+    where.superficieM2 = {
+      ...(filtros.minSuperficie != null ? { gte: filtros.minSuperficie } : {}),
+      ...(filtros.maxSuperficie != null ? { lte: filtros.maxSuperficie } : {})
+    }
+  }
+
+  if (filtros.dormitoriosMin !== undefined || filtros.dormitoriosMax !== undefined) {
+    where.nroCuartos = {
+      ...(filtros.dormitoriosMin !== undefined ? { gte: filtros.dormitoriosMin } : {}),
+      ...(filtros.dormitoriosMax !== undefined ? { lte: filtros.dormitoriosMax } : {})
+    }
+  }
+
+  if (filtros.banosMin !== undefined || filtros.banosMax !== undefined) {
+    where.nroBanos = {
+      ...(filtros.banosMin !== undefined ? { gte: filtros.banosMin } : {}),
+      ...(filtros.banosMax !== undefined ? { lte: filtros.banosMax } : {})
+    }
+  }
+
+  if (filtros.barrioId && filtros.barrioId !== 'todos') {
+    where.ubicacion = { barrio_id: Number(filtros.barrioId) }
+  } else if (filtros.zonaId && filtros.zonaId !== 'todos') {
+    where.ubicacion = { barrio: { zona_id: Number(filtros.zonaId) } }
+  } else if (filtros.municipioId && filtros.municipioId !== 'todos') {
+    where.ubicacion = {
+      barrio: { zona: { municipio_id: Number(filtros.municipioId) } }
+    }
+  } else if (filtros.provinciaId && filtros.provinciaId !== 'todos') {
+    where.ubicacion = {
+      barrio: {
+        zona: { municipio: { provincia_id: Number(filtros.provinciaId) } }
+      }
+    }
+  } else if (filtros.departamentoId && filtros.departamentoId !== 'todos') {
+    where.ubicacion = {
+      barrio: {
+        zona: {
+          municipio: {
+            provincia: { departamento_id: Number(filtros.departamentoId) }
+          }
+        }
+      }
+    }
+  }
+
+  return where
+}
 
 const getAll = async () => {
   return tagsRepository.findAll()
+}
+
+const getTagsWithCounts = async (filtros: TagsContextFilters) => {
+  const inmuebleWhere = buildInmuebleWhereFromFilters(filtros)
+  return tagsRepository.findAllWithContextualCounts(inmuebleWhere)
 }
 
 const getTagsByPublicacion = async (publicacionId: number) => {
@@ -14,10 +145,7 @@ const replacePublicacionTags = async (publicacionId: number, userId: number, nom
   const publicacion = await tagsRepository.findPublicacionOwner(publicacionId)
 
   if (!publicacion) throw new Error('PUBLICATION_NOT_FOUND')
-
-  if (publicacion.usuarioId !== userId) {
-    throw new Error('FORBIDDEN')
-  }
+  if (publicacion.usuarioId !== userId) throw new Error('FORBIDDEN')
 
   const nombresNormalizados = [...new Set(nombres.map((tag) => tag.trim().toLowerCase()))]
 
@@ -37,6 +165,7 @@ const replacePublicacionTags = async (publicacionId: number, userId: number, nom
 
 export const tagsService = {
   getAll,
+  getTagsWithCounts,
   getTagsByPublicacion,
   replacePublicacionTags
 }


### PR DESCRIPTION
## 📋 Descripción

Corrección del bug BUG-336-01 reportado por QA: el filtro de etiquetas
no reflejaba resultados al combinarse con otros filtros activos.
Se implementaron dos cambios para resolverlo.

---

## 🐛 Bug resuelto — BUG-336-01

**Causa raíz:** la lógica AND exigía que cada inmueble tuviera TODAS
las etiquetas seleccionadas, lo que con pocos datos en BD llevaba
frecuentemente a 0 resultados al combinarse con precio, zona u otros
filtros activos.

---

## ✅ Cambios realizados

### Cambio 1 — OR en filtro de etiquetas (`properties.repository.ts`)

Cuando el usuario selecciona múltiples etiquetas, ahora se muestran
inmuebles que tengan AL MENOS UNA de las etiquetas seleccionadas.

```typescript
// ❌ ANTES (AND — devolvía 0 fácilmente):
where.AND = labels.map(id => ({
  publicaciones: { some: { publicacion_tag: { some: { tag_id: id } } } }
}))

// ✅ DESPUÉS (OR — muestra unión de resultados):
where.publicaciones = {
  some: {
    estado: 'ACTIVA',
    publicacion_tag: { some: { tag_id: { in: filtros.labels } } }
  }
}
```

### Cambio 2 — Conteo contextual de etiquetas (`tags/`)

La sección "Disponibles" ahora muestra el conteo de propiedades
dentro del contexto de los filtros activos (precio, zona, superficie,
capacidad). Si hay filtro de precio $50k-$100k activo, el contador
de cada etiqueta refleja cuántas propiedades en ese rango tienen
esa etiqueta.

Nuevo endpoint: `GET /api/tags/counts?minPrice=...&currency=...`

Archivos modificados en el módulo `tags/`:
- `tags.repository.ts` → `findAllWithContextualCounts(inmuebleWhere)`
- `tags.service.ts` → `buildInmuebleWhereFromFilters` + `getTagsWithCounts`
- `tags.controller.ts` → `getTagsWithCountsController`
- `tags.routes.ts` → `GET /counts` antes de `/publicaciones/:id`

---

## 📋 Nota sobre el reporte del QA

El caso reportado (Garaje + precio $50k-$100k → 0 resultados) era
matemáticamente correcto con AND: las 3 propiedades de Garaje cuestan
menos de $50k. Con OR y conteo contextual, el usuario verá etiquetas
con propiedades reales dentro de su rango antes de seleccionarlas.

La observación sobre "gestión de etiquetas" corresponde al equipo
de Publicaciones, fuera del alcance de este módulo.

---

## 🧪 Lint
`pnpm lint:front` → 0 errors  
`pnpm lint:back` → 0 errors

## 📁 Archivos modificados
- `backend/src/modules/properties/properties.repository.ts`
- `backend/src/modules/tags/tags.repository.ts`
- `backend/src/modules/tags/tags.service.ts`
- `backend/src/modules/tags/tags.controller.ts`
- `backend/src/modules/tags/tags.routes.ts`