### PR TITLE
Hotfix/home blogs

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -484,8 +484,8 @@ html.dark body :where([class*="bg-white"],
   [class*="bg-[#f5"],
   [class*="bg-[#F5"],
   [class*="bg-[#f8"],
-  [class*="bg-[#F8"]):not([class*="/"]):not([class*="bg-[#D97706]"]):not([class*="bg-[#d97706]"]):not([aria-pressed="true"]) {
-  background: var(--pb-surface) !important;
+  [class*="bg-[#F8"]):not([class*="/"]):not([class*="bg-[#D97706]"]):not([class*="bg-[#d97706]"]):not([aria-pressed="true"]):not([class*="hover:!bg-"]):not([class*="dark:hover:!bg-"]) {
+  background-color: var(--pb-surface) !important;
   background-image: none !important;
   color: var(--pb-text) !important;
 }
@@ -535,7 +535,7 @@ html.dark :where(nav [class*="absolute"],
 html.dark :where(nav [class*="absolute"] *,
   nav [class*="fixed"] *,
   [role="menu"] *,
-  [role="dialog"] *) {
+  [role="dialog"] *):not([class*="hover:text-"]):not([class*="dark:hover:text-"]):not([class*="text-[#"]) {
   color: var(--pb-text) !important;
   border-color: var(--pb-border) !important;
 }
@@ -558,7 +558,7 @@ html.dark body :where(h1,
   [class*="text-slate"],
   [class*="text-neutral"],
   [class*="text-zinc"],
-  [class*="text-stone"]) {
+  [class*="text-stone"]):not([class*="hover:text-"]):not([class*="dark:hover:text-"]):not([class*="text-[#"]) {
   color: var(--pb-text) !important;
 }
 
@@ -638,7 +638,7 @@ html.dark body :where([class*="bg-amber-500"],
 /* Hover general */
 html.dark body :where(a:hover,
   button:hover,
-  [role="menuitem"]:hover) {
+  [role="menuitem"]:hover):not([class*="dark:hover:bg-"]):not([class*="/"]):not([class*="hover:!bg-"]):not([class*="dark:hover:!bg-"]) {
   background-color: var(--pb-surface-2) !important;
 }
 

--- a/frontend/src/components/blog/admin/AdminBlogReview.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogReview.tsx
@@ -44,7 +44,7 @@ function StatusBanner({
         Estado actual
       </p>
       <h2 className="mt-2 text-2xl font-bold font-montserrat">Artículo rechazado</h2>
-      <p className="mt-2 text-sm leading-7">
+      <p className="mt-2 text-sm leading-7 break-words">
         Comentario registrado: {rejectionComment || "Sin comentario adicional."}
       </p>
     </div>

--- a/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
+++ b/frontend/src/components/blog/admin/AdminBlogsModeration.tsx
@@ -111,7 +111,7 @@ function BlogRow({ blog }: { blog: AdminModerationBlog }) {
       </div>
 
       {blog.status === 'RECHAZADO' && blog.rejectionComment && (
-        <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700 md:col-span-5 font-inter">
+        <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-700 md:col-span-5 font-inter truncate" title={blog.rejectionComment}>
           <span className="font-semibold">Comentario de rechazo:</span> {blog.rejectionComment}
         </div>
       )}
@@ -179,8 +179,8 @@ export default function AdminBlogsModeration() {
                   type="button"
                   onClick={() => setActiveFilter(filter.value)}
                   className={`inline-flex min-h-[46px] items-center justify-center rounded-full px-4 text-xs font-semibold uppercase tracking-[0.16em] transition-colors font-inter ${activeFilter === filter.value
-                      ? 'bg-amber-600 text-white'
-                      : 'text-stone-500 hover:bg-stone-100 hover:text-stone-800'
+                    ? 'bg-amber-600 text-white'
+                    : 'text-stone-500 hover:bg-stone-100 hover:text-stone-800'
                     }`}
                 >
                   {filter.label}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -571,11 +571,10 @@ export default function Navbar() {
                               role="tab"
                               aria-selected={filter === item}
                               onClick={() => setFilter(item)}
-                              className={`rounded-full px-3 py-1 text-xs font-medium transition ${
-                                filter === item
+                              className={`rounded-full px-3 py-1 text-xs font-medium transition ${filter === item
                                   ? "bg-amber-600 text-white"
                                   : "bg-stone-100 text-stone-700 hover:bg-stone-200"
-                              }`}
+                                }`}
                             >
                               {item === "todas"
                                 ? "Todas"
@@ -652,11 +651,10 @@ export default function Navbar() {
                                       router.push(`/notificaciones/${notification.id}`);
                                     }
                                   }}
-                                  className={`cursor-pointer border-b border-stone-100 px-4 py-3 transition hover:bg-stone-50 ${
-                                    notification.status === "no leida"
+                                  className={`cursor-pointer border-b border-stone-100 px-4 py-3 transition hover:bg-stone-50 ${notification.status === "no leida"
                                       ? "bg-amber-50"
                                       : "bg-white"
-                                  }`}
+                                    }`}
                                 >
                                   <div className="flex items-start justify-between gap-3">
                                     <div className="min-w-0 flex-1">
@@ -678,22 +676,22 @@ export default function Navbar() {
                                       <div className="mt-2 flex flex-wrap items-center gap-2">
                                         {notification.tipo ===
                                           "BLOG_APROBADO" && (
-                                          <span className="rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
-                                            Aprobado
-                                          </span>
-                                        )}
+                                            <span className="rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
+                                              Aprobado
+                                            </span>
+                                          )}
                                         {notification.tipo ===
                                           "BLOG_RECHAZADO" && (
-                                          <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-600">
-                                            Rechazado
-                                          </span>
-                                        )}
+                                            <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-600">
+                                              Rechazado
+                                            </span>
+                                          )}
                                         {notification.tipo ===
                                           "BLOG_PENDIENTE" && (
-                                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                                            Pendiente
-                                          </span>
-                                        )}
+                                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                                              Pendiente
+                                            </span>
+                                          )}
                                         <span className="text-[10px] uppercase text-stone-400">
                                           {notification.status}
                                         </span>
@@ -805,14 +803,14 @@ export default function Navbar() {
 
       {isMobileMenuOpen && (
         <div
-          className="fixed inset-0 z-[9999] bg-black/40 lg:hidden"
+          className="fixed inset-0 z-[9999] bg-black/40 dark:bg-white/10 backdrop-blur-md lg:hidden transition-all duration-300"
           onClick={() => setIsMobileMenuOpen(false)}
-          aria-modal="true"
-          role="dialog"
         >
           <div
             className="fixed right-0 top-0 h-full w-4/5 max-w-xs bg-[#F9F6EE] dark:bg-stone-900 p-6 shadow-xl overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
+            aria-modal="true"
+            role="dialog"
           >
             <div className="flex items-center justify-between">
               <Logo />
@@ -839,8 +837,9 @@ export default function Navbar() {
                   retroceder desde "tour-notificaciones" al paso anterior. */}
               <button
                 id="tour-publicar-home-mobile"
-                onClick={() => {setIsMobileMenuOpen(false);
-                void handlePublicarInmueble();
+                onClick={() => {
+                  setIsMobileMenuOpen(false);
+                  void handlePublicarInmueble();
                 }}
                 className="rounded-md px-3 py-2 text-lg font-bold text-[#E68B25] hover:bg-[#E68B25]/10"
               >
@@ -888,7 +887,7 @@ export default function Navbar() {
                         };
                         const currentFilters = JSON.parse(
                           sessionStorage.getItem("propbol_global_filters") ||
-                            "{}",
+                          "{}",
                         );
                         sessionStorage.setItem(
                           "propbol_global_filters",

--- a/frontend/src/components/navbar/NavLinks.tsx
+++ b/frontend/src/components/navbar/NavLinks.tsx
@@ -28,7 +28,7 @@ export default function NavLinks() {
   }, []);
 
   const linkStyle =
-    "hover:text-[#E68B25] hover:bg-[#E68B25]/10 px-3 py-2 rounded-md transition";
+    "hover:!text-[#E68B25] hover:bg-[#E68B25]/10 px-3 py-2 rounded-md transition";
 
   return (
     <div className="hidden lg:flex items-center gap-6 text-[15px] font-medium text-gray-700 dark:text-gray-300">
@@ -38,15 +38,14 @@ export default function NavLinks() {
           onClick={() => setOpen(!open)}
           className={`flex items-center gap-1 px-3 py-2 rounded-md transition ${
             open
-              ? "text-[#E68B25] bg-[#E68B25]/10"
-              : "hover:text-[#E68B25] hover:bg-[#E68B25]/10"
+              ? "!text-[#E68B25] bg-[#E68B25]/10"
+              : "hover:!text-[#E68B25] hover:bg-[#E68B25]/10"
           }`}
         >
           Propiedades
           <ChevronDown
-            className={`h-4 w-4 transition-transform ${
-              open ? "rotate-180" : ""
-            }`}
+            className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""
+              }`}
           />
         </button>
 
@@ -62,6 +61,7 @@ export default function NavLinks() {
               <button
                 key={item}
                 type="button"
+                aria-label={item}
                 data-confirm-exit="true"
                 onClick={() => {
                   setOpen(false);
@@ -108,7 +108,7 @@ export default function NavLinks() {
 
                   router.push(`/busqueda_mapa?${params.toString()}`);
                 }}
-                className="block w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-[#222] hover:text-[#E68B25]"
+                className="block w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:!bg-stone-800 hover:!text-[#E68B25]"
               >
                 {item}
               </button>
@@ -147,8 +147,8 @@ export default function NavLinks() {
           }, 300);
         }}
         className={linkStyle}
-        >
-         Ayuda
+      >
+        Ayuda
       </button>
     </div>
   );


### PR DESCRIPTION
🐛 Problemas solucionados
Mobile Menu Overlay: El fondo translúcido/desenfocado del menú móvil se veía negro sólido en modo oscuro.
NavLinks Hover States: Los enlaces principales del Navbar y los elementos del menú desplegable de "Propiedades" perdían sus colores de hover (texto naranja y fondo gris) por reglas globales que forzaban color blanco y fondo negro.
Botones desplegables color naranja: Los elementos del menú desplegable se pintaban de color naranja sólido debido a una regla dirigida a botones principales de popups (button:not([aria-label]) dentro de .absolute).
🔧 Cambios realizados
src/app/globals.css:
Se añadieron exclusiones dinámicas :not([class*="hover..."]) a las reglas que fuerzan el texto blanco (color: var(--pb-text)) y fondo negro (background) para respetar las directivas explícitas de Tailwind.
Se cambió el shorthand background por background-color en reglas clave para no anular utilidades de Tailwind en estados como :hover.
src/components/layout/Navbar.tsx:
Se movió el atributo role="dialog" fuera del div principal del overlay para evitar ser capturado por un override agresivo global que anula opacidades en diálogos.
src/components/navbar/NavLinks.tsx:
Se añadió la directiva ! (important) a las clases de texto y fondo en los hovers (ej: hover:!text-[#E68B25]) garantizando el renderizado de la UI de marca.
Se añadió aria-label={item} a los botones del menú de "Propiedades" para excluirlos de la regla global de color de acento de popups.